### PR TITLE
Update spring-boot-starter-parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.4.RELEASE</version>
+        <version>2.2.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>uk.gov.ch</groupId>


### PR DESCRIPTION
Update version of spring-boot-starter-parent to 2.2.2.RELEASE as 2.2.4.RELEASE does not exist