### PR TITLE
Faml 335/service for reports

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyReportRepository.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyReportRepository.java
@@ -1,11 +1,9 @@
 package uk.gov.ch.pscdiscrepanciesapi.repositories;
 
-import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyReportEntity;
 
 @Repository
 public interface PscDiscrepancyReportRepository extends MongoRepository<PscDiscrepancyReportEntity, String> {
-    List<PscDiscrepancyReportEntity> findPscDiscrepancyReportById(String reportId);
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -1,0 +1,28 @@
+package uk.gov.ch.pscdiscrepanciesapi.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.ch.pscdiscrepanciesapi.mappers.PscDiscrepancyReportMapper;
+import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyReportEntity;
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancyReport;
+import uk.gov.ch.pscdiscrepanciesapi.repositories.PscDiscrepancyReportRepository;
+
+import java.util.Optional;
+
+@Service
+public class PscDiscrepancyReportService {
+
+    @Autowired
+    private PscDiscrepancyReportRepository pscDiscrepancyReportRepository;
+
+    @Autowired
+    private PscDiscrepancyReportMapper pscDiscrepancyReportMapper;
+
+    public PscDiscrepancyReport findPscDiscrepancyReportById(String reportId) {
+        Optional<PscDiscrepancyReportEntity> storedReport =
+                pscDiscrepancyReportRepository.findById(reportId);
+
+        return storedReport.map(pscDiscrepancyReportEntity -> pscDiscrepancyReportMapper
+                .entityToRest(pscDiscrepancyReportEntity)).orElse(null);
+    }
+}

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
@@ -45,10 +45,13 @@ public class PscDiscrepancyReportServiceUnitTest {
     @Test
     @DisplayName("Test findByPscDiscrepancyReportId is successful")
     void verifyFindByIdSuccessful() {
-        when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(pscDiscrepancyReportEntity));
-        when(mockReportMapper.entityToRest(pscDiscrepancyReportEntity)).thenReturn(pscDiscrepancyReport);
+        when(mockReportRepo.findById(REPORT_ID))
+                .thenReturn(Optional.of(pscDiscrepancyReportEntity));
+        when(mockReportMapper.entityToRest(pscDiscrepancyReportEntity))
+                .thenReturn(pscDiscrepancyReport);
 
-        PscDiscrepancyReport result = pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
+        PscDiscrepancyReport result =
+                pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
 
         assertNotNull(pscDiscrepancyReport);
         assertEquals(pscDiscrepancyReport, result);
@@ -59,7 +62,8 @@ public class PscDiscrepancyReportServiceUnitTest {
     void verifyFindByIdUnsuccessful() {
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.empty());
 
-        PscDiscrepancyReport result = pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
+        PscDiscrepancyReport result =
+                pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
 
         assertNull(result);
     }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
@@ -1,0 +1,66 @@
+package uk.gov.ch.pscdiscrepanciesapi.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ch.pscdiscrepanciesapi.mappers.PscDiscrepancyReportMapper;
+import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyReportEntity;
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancyReport;
+import uk.gov.ch.pscdiscrepanciesapi.repositories.PscDiscrepancyReportRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PscDiscrepancyReportServiceUnitTest {
+
+    private static final String REPORT_ID = "reportId";
+
+    private PscDiscrepancyReport pscDiscrepancyReport;
+    private PscDiscrepancyReportEntity pscDiscrepancyReportEntity;
+
+    @Mock
+    private PscDiscrepancyReportMapper mockReportMapper;
+
+    @Mock
+    private PscDiscrepancyReportRepository mockReportRepo;
+
+    @InjectMocks
+    private PscDiscrepancyReportService pscDiscrepancyReportService;
+
+    @BeforeEach
+    void setUp() {
+        pscDiscrepancyReport = new PscDiscrepancyReport();
+        pscDiscrepancyReportEntity = new PscDiscrepancyReportEntity();
+    }
+
+    @Test
+    @DisplayName("Test findByPscDiscrepancyReportId is successful")
+    void verifyFindByIdSuccessful() {
+        when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(pscDiscrepancyReportEntity));
+        when(mockReportMapper.entityToRest(pscDiscrepancyReportEntity)).thenReturn(pscDiscrepancyReport);
+
+        PscDiscrepancyReport result = pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
+
+        assertNotNull(pscDiscrepancyReport);
+        assertEquals(pscDiscrepancyReport, result);
+    }
+
+    @Test
+    @DisplayName("Test findByPscDiscrepancyReportId is unsuccessful")
+    void verifyFindByIdUnsuccessful() {
+        when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.empty());
+
+        PscDiscrepancyReport result = pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
Service class was created along with appropriat unit tests
The extra findPscDiscrepancyReportById method was deleted as the
MongoRepository superclass already provides a method by default
for this

Resolves FAML-335