### PR TITLE
Feature/faml 365 discrepancy details get

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
@@ -8,10 +8,11 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.ch.pscdiscrepanciesapi.PscDiscrepancyApiApplication;
@@ -41,7 +42,7 @@ public class PscDiscrepancyController {
         this.pscDiscrepancyService = pscDiscrepancyService;
     }
 
-    @RequestMapping(method = RequestMethod.POST)
+    @PostMapping
     public ResponseEntity<ChResponseBody<PscDiscrepancy>> createPscDiscrepancy(
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
             @Valid @RequestBody PscDiscrepancy pscDiscrepancy, HttpServletRequest request) {
@@ -67,7 +68,7 @@ public class PscDiscrepancyController {
         return pscDiscrepancytoReturn;
     }
 
-    @RequestMapping(value= {"/{discrepancy-id}"}, method = RequestMethod.GET)
+    @GetMapping("/{discrepancy-id}")
     public ResponseEntity<ChResponseBody<PscDiscrepancy>> getDiscrepancy(
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
             @PathVariable("discrepancy-id") String pscDiscrepancyId, HttpServletRequest request) {
@@ -87,7 +88,7 @@ public class PscDiscrepancyController {
         return pscDiscrepancyToReturn;
     }
 
-    @RequestMapping(method = RequestMethod.GET)
+    @GetMapping
     public ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> getDiscrepancies(
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId, HttpServletRequest request) {
         ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> pscDiscrepanciesToReturn;

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
@@ -8,9 +8,7 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -74,10 +72,12 @@ public class PscDiscrepancyController {
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
             @PathVariable("discrepancy-id") String pscDiscrepancyId, HttpServletRequest request) {
         ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancyToReturn;
-        Map<String, Object> debugMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject(pscDiscrepancyReportId, pscDiscrepancyId);
+        Map<String, Object> debugMap = 
+                pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject(pscDiscrepancyReportId, pscDiscrepancyId);
         try {
             LOG.info("Retrieving discrepancy for discrepancy report", debugMap);
-            ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService.getDiscrepancy(pscDiscrepancyId);
+            ServiceResult<PscDiscrepancy> pscDiscrepancyResult = 
+                    pscDiscrepancyService.getDiscrepancy(pscDiscrepancyReportId, pscDiscrepancyId, request);
             pscDiscrepancyToReturn = responseFactory.createResponse(pscDiscrepancyResult);
         } catch (ServiceException e) {
             LOG.error("Error retrieving discrepancy for report", debugMap);
@@ -95,7 +95,7 @@ public class PscDiscrepancyController {
         try {
             LOG.info("Retrieving all discrepancies for discrepancy report", debugMap);
             ServiceResult<List<PscDiscrepancy>> pscDiscrepancyList = pscDiscrepancyService
-                    .getDiscrepancies(pscDiscrepancyReportId);
+                    .getDiscrepancies(pscDiscrepancyReportId, request);
             pscDiscrepanciesToReturn = responseFactory.createResponse(pscDiscrepancyList);
         } catch (ServiceException se) {
             LOG.error("Error retrieving all discrepancies for report", debugMap);

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
@@ -1,5 +1,6 @@
 package uk.gov.ch.pscdiscrepanciesapi.controllers;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -7,6 +8,7 @@ import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,42 +29,70 @@ import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactor
 @RequestMapping("/psc-discrepancy-reports/{discrepancy-report-id}/discrepancies")
 public class PscDiscrepancyController {
 
-    private final PscDiscrepancyService pscDiscrepancyService;
+	private final PscDiscrepancyService pscDiscrepancyService;
 
-    private final PluggableResponseEntityFactory responseFactory;
+	private final PluggableResponseEntityFactory responseFactory;
 
-    private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
-    
-    @Autowired
-    public PscDiscrepancyController(PluggableResponseEntityFactory responseFactory,
-            PscDiscrepancyService pscDiscrepancyService) {
-        this.responseFactory = responseFactory;
-        this.pscDiscrepancyService = pscDiscrepancyService;
-    }
+	private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
 
-    @PostMapping
-    public ResponseEntity<ChResponseBody<PscDiscrepancy>> createPscDiscrepancy(
-            @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
-            @Valid @RequestBody PscDiscrepancy pscDiscrepancy, HttpServletRequest request) {
+	@Autowired
+	public PscDiscrepancyController(PluggableResponseEntityFactory responseFactory,
+			PscDiscrepancyService pscDiscrepancyService) {
+		this.responseFactory = responseFactory;
+		this.pscDiscrepancyService = pscDiscrepancyService;
+	}
 
-        ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancytoReturn;
-        try {
-            LOG.infoContext(pscDiscrepancyReportId,
-                    "Create a discrepancy for a PSC discrepancy report", pscDiscrepancyService
-                            .createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
-            ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService
-                    .createPscDiscrepancy(pscDiscrepancy, pscDiscrepancyReportId, request);
-            pscDiscrepancytoReturn = responseFactory.createResponse(pscDiscrepancyResult);
-        } catch (ServiceException e) {
-            final Map<String, Object> debugMap = pscDiscrepancyService
-                    .createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy);
-            LOG.errorRequest(request, e, debugMap);
-            // log wrapped cause exception too, as there is a bug in logger that cannot extract
-            // causes
-            LOG.errorRequest(request, (Exception) e.getCause(), debugMap);
-            pscDiscrepancytoReturn = responseFactory.createEmptyInternalServerError();
-        }
+	@PostMapping
+	public ResponseEntity<ChResponseBody<PscDiscrepancy>> createPscDiscrepancy(
+			@PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
+			@Valid @RequestBody PscDiscrepancy pscDiscrepancy, HttpServletRequest request) {
 
-        return pscDiscrepancytoReturn;
-    }
+		ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancytoReturn;
+		try {
+			LOG.infoContext(pscDiscrepancyReportId, "Create a discrepancy for a PSC discrepancy report",
+					pscDiscrepancyService.createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
+			ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService
+					.createPscDiscrepancy(pscDiscrepancy, pscDiscrepancyReportId, request);
+			pscDiscrepancytoReturn = responseFactory.createResponse(pscDiscrepancyResult);
+		} catch (ServiceException e) {
+			final Map<String, Object> debugMap = pscDiscrepancyService
+					.createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy);
+			LOG.errorRequest(request, e, debugMap);
+			// log wrapped cause exception too, as there is a bug in logger that cannot
+			// extract
+			// causes
+			LOG.errorRequest(request, (Exception) e.getCause(), debugMap);
+			pscDiscrepancytoReturn = responseFactory.createEmptyInternalServerError();
+		}
+
+		return pscDiscrepancytoReturn;
+	}
+
+	@GetMapping
+	public ResponseEntity<ChResponseBody<PscDiscrepancy>> getDiscrepancy(
+			@PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
+			@PathVariable("discrepancy-id") String pscDiscrepancyId, HttpServletRequest request) {
+		ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancyToReturn;
+		try {
+			ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService.getDiscrepancy(pscDiscrepancyId);
+			pscDiscrepancyToReturn = responseFactory.createResponse(pscDiscrepancyResult);
+		} catch (ServiceException e) {
+			pscDiscrepancyToReturn = responseFactory.createEmptyInternalServerError();
+		}
+		return pscDiscrepancyToReturn;
+	}
+
+	@GetMapping
+	public ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> getDiscrepancies(
+			@PathVariable("discrepancy-report-id") String pscDiscrepancyReportId, HttpServletRequest request) {
+		ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> pscDiscrepanciesToReturn;
+		try {
+			ServiceResult<List<PscDiscrepancy>> pscDiscrepancyList = pscDiscrepancyService
+					.getDiscrepancies(pscDiscrepancyReportId);
+			pscDiscrepanciesToReturn = responseFactory.createResponse(pscDiscrepancyList);
+		} catch (ServiceException se) {
+			pscDiscrepanciesToReturn = responseFactory.createEmptyInternalServerError();
+		}
+		return pscDiscrepanciesToReturn;
+	}
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.gov.ch.pscdiscrepanciesapi.PscDiscrepancyApiApplication;
@@ -29,11 +30,11 @@ import uk.gov.companieshouse.service.rest.response.PluggableResponseEntityFactor
 @RequestMapping("/psc-discrepancy-reports/{discrepancy-report-id}/discrepancies")
 public class PscDiscrepancyController {
 
-	private final PscDiscrepancyService pscDiscrepancyService;
+    private final PscDiscrepancyService pscDiscrepancyService;
 
-	private final PluggableResponseEntityFactory responseFactory;
+    private final PluggableResponseEntityFactory responseFactory;
 
-	private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
+    private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
 
     @Autowired
     public PscDiscrepancyController(PluggableResponseEntityFactory responseFactory,
@@ -42,7 +43,7 @@ public class PscDiscrepancyController {
         this.pscDiscrepancyService = pscDiscrepancyService;
     }
 
-    @PostMapping
+    @RequestMapping(method = RequestMethod.POST)
     public ResponseEntity<ChResponseBody<PscDiscrepancy>> createPscDiscrepancy(
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
             @Valid @RequestBody PscDiscrepancy pscDiscrepancy, HttpServletRequest request) {
@@ -68,29 +69,37 @@ public class PscDiscrepancyController {
         return pscDiscrepancytoReturn;
     }
 
-    @GetMapping("/discrepancy-id")
+    @RequestMapping(value= {"/{discrepancy-id}"}, method = RequestMethod.GET)
     public ResponseEntity<ChResponseBody<PscDiscrepancy>> getDiscrepancy(
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
             @PathVariable("discrepancy-id") String pscDiscrepancyId, HttpServletRequest request) {
         ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancyToReturn;
+        Map<String, Object> debugMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject(pscDiscrepancyReportId, pscDiscrepancyId);
         try {
+            LOG.info("Retrieving discrepancy for discrepancy report", debugMap);
             ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService.getDiscrepancy(pscDiscrepancyId);
             pscDiscrepancyToReturn = responseFactory.createResponse(pscDiscrepancyResult);
         } catch (ServiceException e) {
+            LOG.error("Error retrieving discrepancy for report", debugMap);
+            LOG.errorRequest(request, (Exception) e.getCause(), debugMap);
             pscDiscrepancyToReturn = responseFactory.createEmptyInternalServerError();
         }
         return pscDiscrepancyToReturn;
     }
 
-    @GetMapping
+    @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> getDiscrepancies(
             @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId, HttpServletRequest request) {
         ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> pscDiscrepanciesToReturn;
+        Map<String, Object> debugMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject(pscDiscrepancyReportId,null);
         try {
+            LOG.info("Retrieving all discrepancies for discrepancy report", debugMap);
             ServiceResult<List<PscDiscrepancy>> pscDiscrepancyList = pscDiscrepancyService
                     .getDiscrepancies(pscDiscrepancyReportId);
             pscDiscrepanciesToReturn = responseFactory.createResponse(pscDiscrepancyList);
         } catch (ServiceException se) {
+            LOG.error("Error retrieving all discrepancies for report", debugMap);
+            LOG.errorRequest(request, (Exception) se.getCause(), debugMap);
             pscDiscrepanciesToReturn = responseFactory.createEmptyInternalServerError();
         }
         return pscDiscrepanciesToReturn;

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyController.java
@@ -35,64 +35,64 @@ public class PscDiscrepancyController {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
 
-	@Autowired
-	public PscDiscrepancyController(PluggableResponseEntityFactory responseFactory,
-			PscDiscrepancyService pscDiscrepancyService) {
-		this.responseFactory = responseFactory;
-		this.pscDiscrepancyService = pscDiscrepancyService;
-	}
+    @Autowired
+    public PscDiscrepancyController(PluggableResponseEntityFactory responseFactory,
+            PscDiscrepancyService pscDiscrepancyService) {
+        this.responseFactory = responseFactory;
+        this.pscDiscrepancyService = pscDiscrepancyService;
+    }
 
-	@PostMapping
-	public ResponseEntity<ChResponseBody<PscDiscrepancy>> createPscDiscrepancy(
-			@PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
-			@Valid @RequestBody PscDiscrepancy pscDiscrepancy, HttpServletRequest request) {
+    @PostMapping
+    public ResponseEntity<ChResponseBody<PscDiscrepancy>> createPscDiscrepancy(
+            @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
+            @Valid @RequestBody PscDiscrepancy pscDiscrepancy, HttpServletRequest request) {
 
-		ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancytoReturn;
-		try {
-			LOG.infoContext(pscDiscrepancyReportId, "Create a discrepancy for a PSC discrepancy report",
-					pscDiscrepancyService.createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
-			ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService
-					.createPscDiscrepancy(pscDiscrepancy, pscDiscrepancyReportId, request);
-			pscDiscrepancytoReturn = responseFactory.createResponse(pscDiscrepancyResult);
-		} catch (ServiceException e) {
-			final Map<String, Object> debugMap = pscDiscrepancyService
-					.createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy);
-			LOG.errorRequest(request, e, debugMap);
-			// log wrapped cause exception too, as there is a bug in logger that cannot
-			// extract
-			// causes
-			LOG.errorRequest(request, (Exception) e.getCause(), debugMap);
-			pscDiscrepancytoReturn = responseFactory.createEmptyInternalServerError();
-		}
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancytoReturn;
+        try {
+            LOG.infoContext(pscDiscrepancyReportId, "Create a discrepancy for a PSC discrepancy report",
+                    pscDiscrepancyService.createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
+            ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService
+                    .createPscDiscrepancy(pscDiscrepancy, pscDiscrepancyReportId, request);
+            pscDiscrepancytoReturn = responseFactory.createResponse(pscDiscrepancyResult);
+        } catch (ServiceException e) {
+            final Map<String, Object> debugMap = pscDiscrepancyService
+                    .createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy);
+            LOG.errorRequest(request, e, debugMap);
+            // log wrapped cause exception too, as there is a bug in logger that cannot
+            // extract
+            // causes
+            LOG.errorRequest(request, (Exception) e.getCause(), debugMap);
+            pscDiscrepancytoReturn = responseFactory.createEmptyInternalServerError();
+        }
 
-		return pscDiscrepancytoReturn;
-	}
+        return pscDiscrepancytoReturn;
+    }
 
-	@GetMapping
-	public ResponseEntity<ChResponseBody<PscDiscrepancy>> getDiscrepancy(
-			@PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
-			@PathVariable("discrepancy-id") String pscDiscrepancyId, HttpServletRequest request) {
-		ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancyToReturn;
-		try {
-			ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService.getDiscrepancy(pscDiscrepancyId);
-			pscDiscrepancyToReturn = responseFactory.createResponse(pscDiscrepancyResult);
-		} catch (ServiceException e) {
-			pscDiscrepancyToReturn = responseFactory.createEmptyInternalServerError();
-		}
-		return pscDiscrepancyToReturn;
-	}
+    @GetMapping("/discrepancy-id")
+    public ResponseEntity<ChResponseBody<PscDiscrepancy>> getDiscrepancy(
+            @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId,
+            @PathVariable("discrepancy-id") String pscDiscrepancyId, HttpServletRequest request) {
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancyToReturn;
+        try {
+            ServiceResult<PscDiscrepancy> pscDiscrepancyResult = pscDiscrepancyService.getDiscrepancy(pscDiscrepancyId);
+            pscDiscrepancyToReturn = responseFactory.createResponse(pscDiscrepancyResult);
+        } catch (ServiceException e) {
+            pscDiscrepancyToReturn = responseFactory.createEmptyInternalServerError();
+        }
+        return pscDiscrepancyToReturn;
+    }
 
-	@GetMapping
-	public ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> getDiscrepancies(
-			@PathVariable("discrepancy-report-id") String pscDiscrepancyReportId, HttpServletRequest request) {
-		ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> pscDiscrepanciesToReturn;
-		try {
-			ServiceResult<List<PscDiscrepancy>> pscDiscrepancyList = pscDiscrepancyService
-					.getDiscrepancies(pscDiscrepancyReportId);
-			pscDiscrepanciesToReturn = responseFactory.createResponse(pscDiscrepancyList);
-		} catch (ServiceException se) {
-			pscDiscrepanciesToReturn = responseFactory.createEmptyInternalServerError();
-		}
-		return pscDiscrepanciesToReturn;
-	}
+    @GetMapping
+    public ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> getDiscrepancies(
+            @PathVariable("discrepancy-report-id") String pscDiscrepancyReportId, HttpServletRequest request) {
+        ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> pscDiscrepanciesToReturn;
+        try {
+            ServiceResult<List<PscDiscrepancy>> pscDiscrepancyList = pscDiscrepancyService
+                    .getDiscrepancies(pscDiscrepancyReportId);
+            pscDiscrepanciesToReturn = responseFactory.createResponse(pscDiscrepancyList);
+        } catch (ServiceException se) {
+            pscDiscrepanciesToReturn = responseFactory.createEmptyInternalServerError();
+        }
+        return pscDiscrepanciesToReturn;
+    }
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyRepository.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyRepository.java
@@ -1,10 +1,16 @@
 package uk.gov.ch.pscdiscrepanciesapi.repositories;
 
+import java.util.List;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntity;
 
 @Repository
 public interface PscDiscrepancyRepository extends MongoRepository<PscDiscrepancyEntity, String> {
+	
+	@Query(value="{'data.links.linksMap.psc-discrepancy-reports' : ?0}")
+	public List<PscDiscrepancyEntity> getDiscrepancies(String reportLink);
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -111,7 +111,7 @@ public class PscDiscrepancyService {
         }
         try {
             Optional<PscDiscrepancyEntity> storedDiscrepancy = pscDiscrepancyRepository.findById(pscDiscrepancyId);
-            if (storedDiscrepancy != null) {
+            if (storedDiscrepancy.isPresent()) {
                 PscDiscrepancy pscDiscrepancy = storedDiscrepancy
                         .map(pscDiscrepancyEntity -> pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity))
                         .orElse(null);

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -194,6 +194,15 @@ public class PscDiscrepancyService {
         debugMap.put(DISCREPANCY_DETAILS, pscDiscrepancy.getDetails());
         return debugMap;
     }
+    
+    public Map<String, Object> createDebugMapWithoutDiscrepancyObject(String pscDiscrepancyReportId, String pscDiscrepancyId){
+        final Map<String, Object> debugMap = new HashMap<>();
+        debugMap.put(DISCREPANCY_REPORT_ID, pscDiscrepancyReportId);
+        if(pscDiscrepancyId != null) {
+            debugMap.put(DISCREPANCY_ID, pscDiscrepancyId);
+        }
+        return debugMap;
+    }
 
     /**
      * Create an error object

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -55,7 +55,7 @@ public class PscDiscrepancyService {
     /**
      * Create a PSC Discrepancy record.
      * 
-     * @param pscDiscrepancy         PSC Discrepancy from UI
+     * @param pscDiscrepancy PSC Discrepancy from UI
      * @param pscDiscrepancyReportId
      * @param request
      * 
@@ -195,6 +195,12 @@ public class PscDiscrepancyService {
         return debugMap;
     }
     
+    /**
+     * Create a debug map for structured logging when there is no PscDiscrepancy object
+     * @param pscDiscrepancyReportId the id of the psc discrepancy report
+     * @param pscDiscrepancyId the id of the psc discrepancy details
+     * @return
+     */
     public Map<String, Object> createDebugMapWithoutDiscrepancyObject(String pscDiscrepancyReportId, String pscDiscrepancyId){
         final Map<String, Object> debugMap = new HashMap<>();
         debugMap.put(DISCREPANCY_REPORT_ID, pscDiscrepancyReportId);

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -1,8 +1,11 @@
 package uk.gov.ch.pscdiscrepanciesapi.services;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
@@ -33,95 +36,162 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 @Service
 public class PscDiscrepancyService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
-    private static final String DISCREPANCY_DETAILS = "details";
+	private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
+	private static final String MUST_NOT_BE_NULL = " must not be null";
+	private static final String DISCREPANCY_DETAILS = "details";
+	private static final String DISCREPANCY_ID = "discrepancy-id";
+	private static final String DISCREPANCY_REPORT_ID = "discrepancy-report-id";
+	private static final String REPORT_PATH = "/psc-discrepancy-reports/";
 
-    @Autowired
-    private PscDiscrepancyRepository pscDiscrepancyRepository;
+	@Autowired
+	private PscDiscrepancyRepository pscDiscrepancyRepository;
 
-    @Autowired
-    private PscDiscrepancyMapper pscDiscrepancyMapper;
+	@Autowired
+	private PscDiscrepancyMapper pscDiscrepancyMapper;
 
-    @Autowired
-    private LinkFactory linkFactory;
+	@Autowired
+	private LinkFactory linkFactory;
 
-    /**
-     * Create a PSC Discrepancy record.
-     * 
-     * @param pscDiscrepancy PSC Discrepancy from UI
-     * @param pscDiscrepancyReportId 
-     * @param request
-     * 
-     * @return PSC Discrepancy record that was created
-     * @throws ServiceException 
-     */
-    public ServiceResult<PscDiscrepancy> createPscDiscrepancy(PscDiscrepancy pscDiscrepancy,
-            String pscDiscrepancyReportId, HttpServletRequest request) throws ServiceException {
+	/**
+	 * Create a PSC Discrepancy record.
+	 * 
+	 * @param pscDiscrepancy         PSC Discrepancy from UI
+	 * @param pscDiscrepancyReportId
+	 * @param request
+	 * 
+	 * @return PSC Discrepancy record that was created
+	 * @throws ServiceException
+	 */
+	public ServiceResult<PscDiscrepancy> createPscDiscrepancy(PscDiscrepancy pscDiscrepancy,
+			String pscDiscrepancyReportId, HttpServletRequest request) throws ServiceException {
 
-        if (pscDiscrepancy.getDetails() == null || pscDiscrepancy.getDetails().isEmpty()) {
-            Errors errData = new Errors();
-            Err error = Err.invalidBodyBuilderWithLocation(DISCREPANCY_DETAILS)
-                    .withError(DISCREPANCY_DETAILS + " must not be null").build();
-            errData.addError(error);
-            return ServiceResult.invalid(errData);
-        } else {
-            try {
-                PscDiscrepancyEntity pscDiscrepancyEntity =
-                        pscDiscrepancyMapper.restToEntity(pscDiscrepancy);
+		if (pscDiscrepancy.getDetails() == null || pscDiscrepancy.getDetails().isEmpty()) {
+			return ServiceResult.invalid(createErrors(DISCREPANCY_DETAILS, MUST_NOT_BE_NULL));
+		} else {
+			try {
+				PscDiscrepancyEntity pscDiscrepancyEntity = pscDiscrepancyMapper.restToEntity(pscDiscrepancy);
 
-                String pscDiscrepancyId = UUID.randomUUID().toString();
-                pscDiscrepancyEntity.setId(pscDiscrepancyId);
-                pscDiscrepancyEntity.setCreatedAt(LocalDateTime.now());
-                pscDiscrepancyEntity.getData().setKind(Kind.PSC_DISCREPANCY);
-                pscDiscrepancyEntity.getData().setEtag(createEtag());
-                pscDiscrepancyEntity.getData()
-                        .setLinks(linksForCreation(pscDiscrepancyId, pscDiscrepancyReportId));
+				String pscDiscrepancyId = UUID.randomUUID().toString();
+				pscDiscrepancyEntity.setId(pscDiscrepancyId);
+				pscDiscrepancyEntity.setCreatedAt(LocalDateTime.now());
+				pscDiscrepancyEntity.getData().setKind(Kind.PSC_DISCREPANCY);
+				pscDiscrepancyEntity.getData().setEtag(createEtag());
+				pscDiscrepancyEntity.getData().setLinks(linksForCreation(pscDiscrepancyId, pscDiscrepancyReportId));
 
-                PscDiscrepancyEntity createdPscDiscrepancyEntity =
-                        pscDiscrepancyRepository.insert(pscDiscrepancyEntity);
+				PscDiscrepancyEntity createdPscDiscrepancyEntity = pscDiscrepancyRepository
+						.insert(pscDiscrepancyEntity);
 
-                PscDiscrepancy createdPscDiscrepancy =
-                        pscDiscrepancyMapper.entityToRest(createdPscDiscrepancyEntity);
+				PscDiscrepancy createdPscDiscrepancy = pscDiscrepancyMapper.entityToRest(createdPscDiscrepancyEntity);
 
-                return ServiceResult.created(createdPscDiscrepancy);
-            } catch (MongoException me) {
-                ServiceException serviceException =
-                        new ServiceException("Exception storing PSC discrepancy: ", me);
-                LOG.errorRequest(request, serviceException,
-                        createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
-                throw serviceException;
-            }
-        }
-    }
-    
-    private String createEtag() {
-        return GenerateEtagUtil.generateEtag();
-    }
-    
-    private Links linksForCreation(String pscDiscrepancyId, String pscDiscrepancyReportId) {
-    	
-        Links links = new Links();
+				return ServiceResult.created(createdPscDiscrepancy);
+			} catch (MongoException me) {
+				ServiceException serviceException = new ServiceException("Exception storing PSC discrepancy: ", me);
+				LOG.errorRequest(request, serviceException,
+						createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
+				throw serviceException;
+			}
+		}
+	}
 
-        String selfLink = linkFactory.createLinkPscDiscrepancy(pscDiscrepancyId, pscDiscrepancyReportId);
-        links.setLink(CoreLinkKeys.SELF, selfLink);
+	/**
+	 * Get a single PSC Discrepancy details record by ID
+	 * 
+	 * @param pscDiscrepancyId
+	 * @param request
+	 * @return the PSC Discrepancy which has the matching ID
+	 * @throws ServiceException
+	 */
+	public ServiceResult<PscDiscrepancy> getDiscrepancy(String pscDiscrepancyId) throws ServiceException {
+		if (pscDiscrepancyId == null || pscDiscrepancyId.isEmpty()) {
+			return ServiceResult.invalid(createErrors(DISCREPANCY_ID, MUST_NOT_BE_NULL));
+		}
+		try {
+			Optional<PscDiscrepancyEntity> storedDiscrepancy = pscDiscrepancyRepository.findById(pscDiscrepancyId);
+			if (storedDiscrepancy != null) {
+			    PscDiscrepancy pscDiscrepancy = storedDiscrepancy
+			            .map(pscDiscrepancyEntity -> pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).orElse(null);
+				return ServiceResult.found(pscDiscrepancy);
+			} else {
+				return ServiceResult.notFound();
+			}
+		} catch (MongoException me) {
+			ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
+			throw serviceException;
+		}
+	}
 
-        String pscDiscrepancyReportLink = linkFactory.createLinkPscDiscrepancyReport(pscDiscrepancyReportId);
-        links.setLink(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT, pscDiscrepancyReportLink);
+	/**
+	 * Get all discrepancies which exist for a given report
+	 * 
+	 * @param pscDiscrepancyReportId the ID of the report
+	 * @return the List of PSC Discrepancies
+	 * @throws ServiceException
+	 */
+	public ServiceResult<List<PscDiscrepancy>> getDiscrepancies(String pscDiscrepancyReportId) throws ServiceException {
+		if (pscDiscrepancyReportId == null || pscDiscrepancyReportId.isEmpty()) {
+			return ServiceResult.invalid(createErrors(DISCREPANCY_REPORT_ID, MUST_NOT_BE_NULL));
+		}
+		try {
+			List<PscDiscrepancyEntity> storedDiscrepancies = pscDiscrepancyRepository
+					.getDiscrepancies(REPORT_PATH + pscDiscrepancyReportId);
+			if (storedDiscrepancies != null && storedDiscrepancies.size() > 0) {
+				List<PscDiscrepancy> retrievedDiscrepancies = new ArrayList<>();
+				for (PscDiscrepancyEntity pscDiscrepancyEntity : storedDiscrepancies) {
+					retrievedDiscrepancies.add(pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity));
+				}
+				return ServiceResult.found(retrievedDiscrepancies);
+			} else {
+				return ServiceResult.notFound();
+			}
+		} catch (MongoException me) {
+			ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
+			throw serviceException;
+		}
+	}
 
-        return links;
-    }
-    
-    /**
-     * Create a debug map for structured logging
-     * 
-     * @param pscDiscrepancy
-     * 
-     * @return Debug map
-     */
-    public Map<String,Object> createPscDiscrepancyDebugMap(String pscDiscrepancyReportId, PscDiscrepancy pscDiscrepancy) {
-        final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("discrepancy-report-id", pscDiscrepancyReportId);
-        debugMap.put(DISCREPANCY_DETAILS, pscDiscrepancy.getDetails());
-        return debugMap;
-    }
+	private String createEtag() {
+		return GenerateEtagUtil.generateEtag();
+	}
+
+	private Links linksForCreation(String pscDiscrepancyId, String pscDiscrepancyReportId) {
+
+		Links links = new Links();
+
+		String selfLink = linkFactory.createLinkPscDiscrepancy(pscDiscrepancyId, pscDiscrepancyReportId);
+		links.setLink(CoreLinkKeys.SELF, selfLink);
+
+		String pscDiscrepancyReportLink = linkFactory.createLinkPscDiscrepancyReport(pscDiscrepancyReportId);
+		links.setLink(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT, pscDiscrepancyReportLink);
+
+		return links;
+	}
+
+	/**
+	 * Create a debug map for structured logging
+	 * 
+	 * @param pscDiscrepancy
+	 * 
+	 * @return Debug map
+	 */
+	public Map<String, Object> createPscDiscrepancyDebugMap(String pscDiscrepancyReportId,
+			PscDiscrepancy pscDiscrepancy) {
+		final Map<String, Object> debugMap = new HashMap<>();
+		debugMap.put("discrepancy-report-id", pscDiscrepancyReportId);
+		debugMap.put(DISCREPANCY_DETAILS, pscDiscrepancy.getDetails());
+		return debugMap;
+	}
+
+	/**
+	 * Create an error object
+	 * 
+	 * @param field   the field that is causing the error
+	 * @param message the message about the field
+	 * @return the completed Errors object
+	 */
+	private Errors createErrors(String field, String message) {
+		Errors errData = new Errors();
+		Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
+		errData.addError(error);
+		return errData;
+	}
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -36,162 +36,163 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 @Service
 public class PscDiscrepancyService {
 
-	private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
-	private static final String MUST_NOT_BE_NULL = " must not be null";
-	private static final String DISCREPANCY_DETAILS = "details";
-	private static final String DISCREPANCY_ID = "discrepancy-id";
-	private static final String DISCREPANCY_REPORT_ID = "discrepancy-report-id";
-	private static final String REPORT_PATH = "/psc-discrepancy-reports/";
+    private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
+    private static final String MUST_NOT_BE_NULL = " must not be null";
+    private static final String DISCREPANCY_DETAILS = "details";
+    private static final String DISCREPANCY_ID = "discrepancy-id";
+    private static final String DISCREPANCY_REPORT_ID = "discrepancy-report-id";
+    private static final String REPORT_PATH = "/psc-discrepancy-reports/";
 
-	@Autowired
-	private PscDiscrepancyRepository pscDiscrepancyRepository;
+    @Autowired
+    private PscDiscrepancyRepository pscDiscrepancyRepository;
 
-	@Autowired
-	private PscDiscrepancyMapper pscDiscrepancyMapper;
+    @Autowired
+    private PscDiscrepancyMapper pscDiscrepancyMapper;
 
-	@Autowired
-	private LinkFactory linkFactory;
+    @Autowired
+    private LinkFactory linkFactory;
 
-	/**
-	 * Create a PSC Discrepancy record.
-	 * 
-	 * @param pscDiscrepancy         PSC Discrepancy from UI
-	 * @param pscDiscrepancyReportId
-	 * @param request
-	 * 
-	 * @return PSC Discrepancy record that was created
-	 * @throws ServiceException
-	 */
-	public ServiceResult<PscDiscrepancy> createPscDiscrepancy(PscDiscrepancy pscDiscrepancy,
-			String pscDiscrepancyReportId, HttpServletRequest request) throws ServiceException {
+    /**
+     * Create a PSC Discrepancy record.
+     * 
+     * @param pscDiscrepancy         PSC Discrepancy from UI
+     * @param pscDiscrepancyReportId
+     * @param request
+     * 
+     * @return PSC Discrepancy record that was created
+     * @throws ServiceException
+     */
+    public ServiceResult<PscDiscrepancy> createPscDiscrepancy(PscDiscrepancy pscDiscrepancy,
+            String pscDiscrepancyReportId, HttpServletRequest request) throws ServiceException {
 
-		if (pscDiscrepancy.getDetails() == null || pscDiscrepancy.getDetails().isEmpty()) {
-			return ServiceResult.invalid(createErrors(DISCREPANCY_DETAILS, MUST_NOT_BE_NULL));
-		} else {
-			try {
-				PscDiscrepancyEntity pscDiscrepancyEntity = pscDiscrepancyMapper.restToEntity(pscDiscrepancy);
+        if (pscDiscrepancy.getDetails() == null || pscDiscrepancy.getDetails().isEmpty()) {
+            return ServiceResult.invalid(createErrors(DISCREPANCY_DETAILS, MUST_NOT_BE_NULL));
+        } else {
+            try {
+                PscDiscrepancyEntity pscDiscrepancyEntity = pscDiscrepancyMapper.restToEntity(pscDiscrepancy);
 
-				String pscDiscrepancyId = UUID.randomUUID().toString();
-				pscDiscrepancyEntity.setId(pscDiscrepancyId);
-				pscDiscrepancyEntity.setCreatedAt(LocalDateTime.now());
-				pscDiscrepancyEntity.getData().setKind(Kind.PSC_DISCREPANCY);
-				pscDiscrepancyEntity.getData().setEtag(createEtag());
-				pscDiscrepancyEntity.getData().setLinks(linksForCreation(pscDiscrepancyId, pscDiscrepancyReportId));
+                String pscDiscrepancyId = UUID.randomUUID().toString();
+                pscDiscrepancyEntity.setId(pscDiscrepancyId);
+                pscDiscrepancyEntity.setCreatedAt(LocalDateTime.now());
+                pscDiscrepancyEntity.getData().setKind(Kind.PSC_DISCREPANCY);
+                pscDiscrepancyEntity.getData().setEtag(createEtag());
+                pscDiscrepancyEntity.getData().setLinks(linksForCreation(pscDiscrepancyId, pscDiscrepancyReportId));
 
-				PscDiscrepancyEntity createdPscDiscrepancyEntity = pscDiscrepancyRepository
-						.insert(pscDiscrepancyEntity);
+                PscDiscrepancyEntity createdPscDiscrepancyEntity = pscDiscrepancyRepository
+                        .insert(pscDiscrepancyEntity);
 
-				PscDiscrepancy createdPscDiscrepancy = pscDiscrepancyMapper.entityToRest(createdPscDiscrepancyEntity);
+                PscDiscrepancy createdPscDiscrepancy = pscDiscrepancyMapper.entityToRest(createdPscDiscrepancyEntity);
 
-				return ServiceResult.created(createdPscDiscrepancy);
-			} catch (MongoException me) {
-				ServiceException serviceException = new ServiceException("Exception storing PSC discrepancy: ", me);
-				LOG.errorRequest(request, serviceException,
-						createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
-				throw serviceException;
-			}
-		}
-	}
+                return ServiceResult.created(createdPscDiscrepancy);
+            } catch (MongoException me) {
+                ServiceException serviceException = new ServiceException("Exception storing PSC discrepancy: ", me);
+                LOG.errorRequest(request, serviceException,
+                        createPscDiscrepancyDebugMap(pscDiscrepancyReportId, pscDiscrepancy));
+                throw serviceException;
+            }
+        }
+    }
 
-	/**
-	 * Get a single PSC Discrepancy details record by ID
-	 * 
-	 * @param pscDiscrepancyId
-	 * @param request
-	 * @return the PSC Discrepancy which has the matching ID
-	 * @throws ServiceException
-	 */
-	public ServiceResult<PscDiscrepancy> getDiscrepancy(String pscDiscrepancyId) throws ServiceException {
-		if (pscDiscrepancyId == null || pscDiscrepancyId.isEmpty()) {
-			return ServiceResult.invalid(createErrors(DISCREPANCY_ID, MUST_NOT_BE_NULL));
-		}
-		try {
-			Optional<PscDiscrepancyEntity> storedDiscrepancy = pscDiscrepancyRepository.findById(pscDiscrepancyId);
-			if (storedDiscrepancy != null) {
-			    PscDiscrepancy pscDiscrepancy = storedDiscrepancy
-			            .map(pscDiscrepancyEntity -> pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).orElse(null);
-				return ServiceResult.found(pscDiscrepancy);
-			} else {
-				return ServiceResult.notFound();
-			}
-		} catch (MongoException me) {
-			ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
-			throw serviceException;
-		}
-	}
+    /**
+     * Get a single PSC Discrepancy details record by ID
+     * 
+     * @param pscDiscrepancyId
+     * @param request
+     * @return the PSC Discrepancy which has the matching ID
+     * @throws ServiceException
+     */
+    public ServiceResult<PscDiscrepancy> getDiscrepancy(String pscDiscrepancyId) throws ServiceException {
+        if (pscDiscrepancyId == null || pscDiscrepancyId.isEmpty()) {
+            return ServiceResult.invalid(createErrors(DISCREPANCY_ID, MUST_NOT_BE_NULL));
+        }
+        try {
+            Optional<PscDiscrepancyEntity> storedDiscrepancy = pscDiscrepancyRepository.findById(pscDiscrepancyId);
+            if (storedDiscrepancy != null) {
+                PscDiscrepancy pscDiscrepancy = storedDiscrepancy
+                        .map(pscDiscrepancyEntity -> pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity))
+                        .orElse(null);
+                return ServiceResult.found(pscDiscrepancy);
+            } else {
+                return ServiceResult.notFound();
+            }
+        } catch (MongoException me) {
+            ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
+            throw serviceException;
+        }
+    }
 
-	/**
-	 * Get all discrepancies which exist for a given report
-	 * 
-	 * @param pscDiscrepancyReportId the ID of the report
-	 * @return the List of PSC Discrepancies
-	 * @throws ServiceException
-	 */
-	public ServiceResult<List<PscDiscrepancy>> getDiscrepancies(String pscDiscrepancyReportId) throws ServiceException {
-		if (pscDiscrepancyReportId == null || pscDiscrepancyReportId.isEmpty()) {
-			return ServiceResult.invalid(createErrors(DISCREPANCY_REPORT_ID, MUST_NOT_BE_NULL));
-		}
-		try {
-			List<PscDiscrepancyEntity> storedDiscrepancies = pscDiscrepancyRepository
-					.getDiscrepancies(REPORT_PATH + pscDiscrepancyReportId);
-			if (storedDiscrepancies != null && storedDiscrepancies.size() > 0) {
-				List<PscDiscrepancy> retrievedDiscrepancies = new ArrayList<>();
-				for (PscDiscrepancyEntity pscDiscrepancyEntity : storedDiscrepancies) {
-					retrievedDiscrepancies.add(pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity));
-				}
-				return ServiceResult.found(retrievedDiscrepancies);
-			} else {
-				return ServiceResult.notFound();
-			}
-		} catch (MongoException me) {
-			ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
-			throw serviceException;
-		}
-	}
+    /**
+     * Get all discrepancies which exist for a given report
+     * 
+     * @param pscDiscrepancyReportId the ID of the report
+     * @return the List of PSC Discrepancies
+     * @throws ServiceException
+     */
+    public ServiceResult<List<PscDiscrepancy>> getDiscrepancies(String pscDiscrepancyReportId) throws ServiceException {
+        if (pscDiscrepancyReportId == null || pscDiscrepancyReportId.isEmpty()) {
+            return ServiceResult.invalid(createErrors(DISCREPANCY_REPORT_ID, MUST_NOT_BE_NULL));
+        }
+        try {
+            List<PscDiscrepancyEntity> storedDiscrepancies = pscDiscrepancyRepository
+                    .getDiscrepancies(REPORT_PATH + pscDiscrepancyReportId);
+            if (storedDiscrepancies != null && storedDiscrepancies.size() > 0) {
+                List<PscDiscrepancy> retrievedDiscrepancies = new ArrayList<>();
+                for (PscDiscrepancyEntity pscDiscrepancyEntity : storedDiscrepancies) {
+                    retrievedDiscrepancies.add(pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity));
+                }
+                return ServiceResult.found(retrievedDiscrepancies);
+            } else {
+                return ServiceResult.notFound();
+            }
+        } catch (MongoException me) {
+            ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
+            throw serviceException;
+        }
+    }
 
-	private String createEtag() {
-		return GenerateEtagUtil.generateEtag();
-	}
+    private String createEtag() {
+        return GenerateEtagUtil.generateEtag();
+    }
 
-	private Links linksForCreation(String pscDiscrepancyId, String pscDiscrepancyReportId) {
+    private Links linksForCreation(String pscDiscrepancyId, String pscDiscrepancyReportId) {
 
-		Links links = new Links();
+        Links links = new Links();
 
-		String selfLink = linkFactory.createLinkPscDiscrepancy(pscDiscrepancyId, pscDiscrepancyReportId);
-		links.setLink(CoreLinkKeys.SELF, selfLink);
+        String selfLink = linkFactory.createLinkPscDiscrepancy(pscDiscrepancyId, pscDiscrepancyReportId);
+        links.setLink(CoreLinkKeys.SELF, selfLink);
 
-		String pscDiscrepancyReportLink = linkFactory.createLinkPscDiscrepancyReport(pscDiscrepancyReportId);
-		links.setLink(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT, pscDiscrepancyReportLink);
+        String pscDiscrepancyReportLink = linkFactory.createLinkPscDiscrepancyReport(pscDiscrepancyReportId);
+        links.setLink(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT, pscDiscrepancyReportLink);
 
-		return links;
-	}
+        return links;
+    }
 
-	/**
-	 * Create a debug map for structured logging
-	 * 
-	 * @param pscDiscrepancy
-	 * 
-	 * @return Debug map
-	 */
-	public Map<String, Object> createPscDiscrepancyDebugMap(String pscDiscrepancyReportId,
-			PscDiscrepancy pscDiscrepancy) {
-		final Map<String, Object> debugMap = new HashMap<>();
-		debugMap.put("discrepancy-report-id", pscDiscrepancyReportId);
-		debugMap.put(DISCREPANCY_DETAILS, pscDiscrepancy.getDetails());
-		return debugMap;
-	}
+    /**
+     * Create a debug map for structured logging
+     * 
+     * @param pscDiscrepancy
+     * 
+     * @return Debug map
+     */
+    public Map<String, Object> createPscDiscrepancyDebugMap(String pscDiscrepancyReportId,
+            PscDiscrepancy pscDiscrepancy) {
+        final Map<String, Object> debugMap = new HashMap<>();
+        debugMap.put("discrepancy-report-id", pscDiscrepancyReportId);
+        debugMap.put(DISCREPANCY_DETAILS, pscDiscrepancy.getDetails());
+        return debugMap;
+    }
 
-	/**
-	 * Create an error object
-	 * 
-	 * @param field   the field that is causing the error
-	 * @param message the message about the field
-	 * @return the completed Errors object
-	 */
-	private Errors createErrors(String field, String message) {
-		Errors errData = new Errors();
-		Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
-		errData.addError(error);
-		return errData;
-	}
+    /**
+     * Create an error object
+     * 
+     * @param field   the field that is causing the error
+     * @param message the message about the field
+     * @return the completed Errors object
+     */
+    private Errors createErrors(String field, String message) {
+        Errors errData = new Errors();
+        Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
+        errData.addError(error);
+        return errData;
+    }
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -105,7 +105,7 @@ public class PscDiscrepancyService {
      * @return the PSC Discrepancy which has the matching ID
      * @throws ServiceException
      */
-    public ServiceResult<PscDiscrepancy> getDiscrepancy(String pscDiscrepancyId) throws ServiceException {
+    public ServiceResult<PscDiscrepancy> getDiscrepancy(String pscDiscrepancyReportId, String pscDiscrepancyId, HttpServletRequest request) throws ServiceException {
         if (pscDiscrepancyId == null || pscDiscrepancyId.isEmpty()) {
             return ServiceResult.invalid(createErrors(DISCREPANCY_ID, MUST_NOT_BE_NULL));
         }
@@ -121,6 +121,7 @@ public class PscDiscrepancyService {
             }
         } catch (MongoException me) {
             ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
+            LOG.errorRequest(request, serviceException, createDebugMapWithoutDiscrepancyObject(pscDiscrepancyReportId, pscDiscrepancyId));
             throw serviceException;
         }
     }
@@ -132,14 +133,14 @@ public class PscDiscrepancyService {
      * @return the List of PSC Discrepancies
      * @throws ServiceException
      */
-    public ServiceResult<List<PscDiscrepancy>> getDiscrepancies(String pscDiscrepancyReportId) throws ServiceException {
+    public ServiceResult<List<PscDiscrepancy>> getDiscrepancies(String pscDiscrepancyReportId, HttpServletRequest request) throws ServiceException {
         if (pscDiscrepancyReportId == null || pscDiscrepancyReportId.isEmpty()) {
             return ServiceResult.invalid(createErrors(DISCREPANCY_REPORT_ID, MUST_NOT_BE_NULL));
         }
         try {
             List<PscDiscrepancyEntity> storedDiscrepancies = pscDiscrepancyRepository
                     .getDiscrepancies(REPORT_PATH + pscDiscrepancyReportId);
-            if (storedDiscrepancies != null && storedDiscrepancies.size() > 0) {
+            if (storedDiscrepancies != null && !storedDiscrepancies.isEmpty()) {
                 List<PscDiscrepancy> retrievedDiscrepancies = new ArrayList<>();
                 for (PscDiscrepancyEntity pscDiscrepancyEntity : storedDiscrepancies) {
                     retrievedDiscrepancies.add(pscDiscrepancyMapper.entityToRest(pscDiscrepancyEntity));
@@ -150,6 +151,7 @@ public class PscDiscrepancyService {
             }
         } catch (MongoException me) {
             ServiceException serviceException = new ServiceException("Exception retrieving PSC discrepancy: ", me);
+            LOG.errorRequest(request, serviceException, createDebugMapWithoutDiscrepancyObject(pscDiscrepancyReportId, null));
             throw serviceException;
         }
     }
@@ -190,7 +192,7 @@ public class PscDiscrepancyService {
     public Map<String, Object> createPscDiscrepancyDebugMap(String pscDiscrepancyReportId,
             PscDiscrepancy pscDiscrepancy) {
         final Map<String, Object> debugMap = new HashMap<>();
-        debugMap.put("discrepancy-report-id", pscDiscrepancyReportId);
+        debugMap.put(DISCREPANCY_REPORT_ID, pscDiscrepancyReportId);
         debugMap.put(DISCREPANCY_DETAILS, pscDiscrepancy.getDetails());
         return debugMap;
     }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyControllerUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyControllerUnitTest.java
@@ -42,32 +42,34 @@ public class PscDiscrepancyControllerUnitTest {
 
     @Mock
     private HttpServletRequest request;
-    
+
     @Mock
     ResponseEntity<ChResponseBody<PscDiscrepancy>> pscDiscrepancytoReturn;
-	
+
     private PscDiscrepancyController pscDiscrepancyController;
 
     @BeforeEach
     void setUp() {
-    	pscDiscrepancy = new PscDiscrepancy();
+        pscDiscrepancy = new PscDiscrepancy();
         PluggableResponseEntityFactory responseFactory = new ResponseEntityFactoriesConfig().createResponseFactory();
-    	pscDiscrepancyController = new PscDiscrepancyController(responseFactory, pscDiscrepancyService);
+        pscDiscrepancyController = new PscDiscrepancyController(responseFactory, pscDiscrepancyService);
     }
 
     @Test
     @DisplayName("When createPscDiscrepancy returns an valid ServiceResult then a Created response is returned with a SuccessBody.")
     void createPscDiscrepancySuccessful() throws ServiceException {
-    	
+
         Links links = new Links();
         links.setLink(CoreLinkKeys.SELF, "/psc-discrepancy-reports/123/discrepancies/456");
         pscDiscrepancy = new PscDiscrepancy();
         pscDiscrepancy.setLinks(links);
-    	ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.created(pscDiscrepancy);
+        ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.created(pscDiscrepancy);
 
-        when(pscDiscrepancyService.createPscDiscrepancy(any(PscDiscrepancy.class), anyString(), any(HttpServletRequest.class))).thenReturn(serviceResult);
-        
-        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = pscDiscrepancyController.createPscDiscrepancy(REPORT_ID, pscDiscrepancy, request);
+        when(pscDiscrepancyService.createPscDiscrepancy(any(PscDiscrepancy.class), anyString(),
+                any(HttpServletRequest.class))).thenReturn(serviceResult);
+
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = pscDiscrepancyController
+                .createPscDiscrepancy(REPORT_ID, pscDiscrepancy, request);
 
         assertNotNull(response);
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -77,7 +79,7 @@ public class PscDiscrepancyControllerUnitTest {
     @Test
     @DisplayName("When createPscDiscrepancy returns an invalid ServiceResult then a Bad Request response is returned with an ErrorBody.")
     void createPscDiscrepancyReturnsValidationServiceResult() throws ServiceException {
-    	
+
         Links links = new Links();
         links.setLink(CoreLinkKeys.SELF, "/psc-discrepancy-reports/123/discrepancies/456");
         pscDiscrepancy = new PscDiscrepancy();
@@ -87,11 +89,13 @@ public class PscDiscrepancyControllerUnitTest {
                 .withError(DISCREPANCY_DETAILS + " must not be null").build();
         errData.addError(error);
 
-    	ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.invalid(errData);
+        ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.invalid(errData);
 
-        when(pscDiscrepancyService.createPscDiscrepancy(any(PscDiscrepancy.class), anyString(), any(HttpServletRequest.class))).thenReturn(serviceResult);
-        
-        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = pscDiscrepancyController.createPscDiscrepancy(REPORT_ID, pscDiscrepancy, request);
+        when(pscDiscrepancyService.createPscDiscrepancy(any(PscDiscrepancy.class), anyString(),
+                any(HttpServletRequest.class))).thenReturn(serviceResult);
+
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = pscDiscrepancyController
+                .createPscDiscrepancy(REPORT_ID, pscDiscrepancy, request);
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -102,11 +106,43 @@ public class PscDiscrepancyControllerUnitTest {
     @DisplayName("When createPscDiscrepancy throws a ServiceException then an Internal Server Error response is returned.")
     void createPscDiscrepancyThrowsServiceException() throws ServiceException {
 
-        doThrow(ServiceException.class).when(pscDiscrepancyService).createPscDiscrepancy(any(PscDiscrepancy.class), anyString(), any(HttpServletRequest.class));
-        
-        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = pscDiscrepancyController.createPscDiscrepancy(REPORT_ID, pscDiscrepancy, request);
+        doThrow(ServiceException.class).when(pscDiscrepancyService).createPscDiscrepancy(any(PscDiscrepancy.class),
+                anyString(), any(HttpServletRequest.class));
+
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = pscDiscrepancyController
+                .createPscDiscrepancy(REPORT_ID, pscDiscrepancy, request);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertNull(response.getBody());
+    }
+    
+    @DisplayName("When getDiscrepancy successfully returns a service response of a discrepancy")
+    void getDiscrepancySuccessful() {
+        
+    }
+    
+    @DisplayName("When getDiscrepancy returns an invalid ServiceResult then a Bad Request is returned with an error body")
+    void getDiscrepancyReturnsValidationServiceResult() {
+        
+    }
+    
+    @DisplayName("When getDiscrepancy throws a ServiceException then an Internal Server Error response is returned")
+    void getDiscrepancyThrowsServiceException() {
+        
+    }
+    
+    @DisplayName("When getDiscrepancies successfully returns a service response of a list of discrepancies")
+    void getDiscrepanciesSuccessful() {
+        
+    }
+    
+    @DisplayName("When getDiscrepancies returns an invalid ServiceResult then a Bad Request is returned with an error body")
+    void getDiscrepanciesReturnValidationServiceResult() {
+        
+    }
+    
+    @DisplayName("When getDiscrepancies throws a ServiceException then an Internal Server Error response is returned")
+    void getDiscrepanciesThrowsServiceException() {
+        
     }
 }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyControllerUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyControllerUnitTest.java
@@ -132,7 +132,7 @@ public class PscDiscrepancyControllerUnitTest {
     void getDiscrepancySuccessful() throws ServiceException {
         pscDiscrepancy = populatePscDiscrepancy();
         ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.found(pscDiscrepancy);
-        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenReturn(serviceResult);
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request)).thenReturn(serviceResult);
         ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
                 pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         
@@ -149,7 +149,7 @@ public class PscDiscrepancyControllerUnitTest {
     @DisplayName("When getDiscrepancy cannot find discrepancy returns Not Found and no response body")
     void getDiscrepancyUnsuccessful() throws ServiceException {
         ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.notFound();
-        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenReturn(serviceResult);
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request)).thenReturn(serviceResult);
         ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
                 pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         
@@ -164,7 +164,7 @@ public class PscDiscrepancyControllerUnitTest {
         Errors errData = createErrors(DISCREPANCY_DETAILS_ID, MUST_NOT_BE_NULL);
         ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.invalid(errData);
         
-        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenReturn(serviceResult);
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request)).thenReturn(serviceResult);
         ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
                 pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         assertNotNull(response);
@@ -175,7 +175,7 @@ public class PscDiscrepancyControllerUnitTest {
     @Test
     @DisplayName("When getDiscrepancy throws a ServiceException then an Internal Server Error response is returned")
     void getDiscrepancyThrowsServiceException() throws ServiceException {
-        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenThrow(new ServiceException(""));
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request)).thenThrow(new ServiceException(""));
         ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
                 pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         
@@ -192,7 +192,7 @@ public class PscDiscrepancyControllerUnitTest {
         discrepancies.add(pscDiscrepancy);
         ServiceResult<List<PscDiscrepancy>> serviceResult = ServiceResult.found(discrepancies);
         
-        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenReturn(serviceResult);
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID, request)).thenReturn(serviceResult);
         
         ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
                 pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
@@ -206,7 +206,7 @@ public class PscDiscrepancyControllerUnitTest {
     @DisplayName("When getDiscrepancies is unsuccessful returns a service response with not found status")
     void getDiscrepanciesUnsuccessful() throws ServiceException {
         ServiceResult<List<PscDiscrepancy>> serviceResult = ServiceResult.notFound();
-        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenReturn(serviceResult);
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID, request)).thenReturn(serviceResult);
         
         ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
                 pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
@@ -221,7 +221,7 @@ public class PscDiscrepancyControllerUnitTest {
     void getDiscrepanciesReturnValidationServiceResult() throws ServiceException {
         Errors errData = createErrors(DISCREPANCY_DETAILS_ID, MUST_NOT_BE_NULL);
         ServiceResult<List<PscDiscrepancy>> serviceResult = ServiceResult.invalid(errData);
-        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenReturn(serviceResult);
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID, request)).thenReturn(serviceResult);
         
         ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
                 pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
@@ -234,7 +234,7 @@ public class PscDiscrepancyControllerUnitTest {
     @Test
     @DisplayName("When getDiscrepancies throws a ServiceException then an Internal Server Error response is returned")
     void getDiscrepanciesThrowsServiceException() throws ServiceException {
-        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenThrow(new ServiceException(""));
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID, request)).thenThrow(new ServiceException(""));
         ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
                 pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
         

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyControllerUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/controllers/PscDiscrepancyControllerUnitTest.java
@@ -8,7 +8,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
 import uk.gov.ch.pscdiscrepanciesapi.common.ResponseEntityFactoriesConfig;
 import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancy;
 import uk.gov.ch.pscdiscrepanciesapi.services.PscDiscrepancyService;
@@ -34,7 +42,11 @@ public class PscDiscrepancyControllerUnitTest {
 
     private static final String REPORT_ID = "reportId";
     private static final String DISCREPANCY_DETAILS = "details";
-    private static final String SELF_LINK = "/psc-discrepancy-reports/123/discrepancies/456";
+    private static final String DISCREPANCY_REPORT_ID = "123";
+    private static final String DISCREPANCY_DETAILS_ID = "456";
+    private static final String REPORT_SELF_LINK = "/psc-discrepancy-reports/" + DISCREPANCY_REPORT_ID;
+    private static final String SELF_LINK = REPORT_SELF_LINK + "/discrepancies/" + DISCREPANCY_DETAILS_ID;
+    private static final String MUST_NOT_BE_NULL = " must not be null";
 
     private PscDiscrepancy pscDiscrepancy;
 
@@ -114,34 +126,140 @@ public class PscDiscrepancyControllerUnitTest {
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertNull(response.getBody());
     }
-    
-    @DisplayName("When getDiscrepancy successfully returns a service response of a discrepancy")
-    void getDiscrepancySuccessful() {
+
+    @Test
+    @DisplayName("When getDiscrepancy successfully returns a discrepancy")
+    void getDiscrepancySuccessful() throws ServiceException {
+        pscDiscrepancy = populatePscDiscrepancy();
+        ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.found(pscDiscrepancy);
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenReturn(serviceResult);
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
+                pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(pscDiscrepancy, response.getBody().getSuccessBody());
+        assertEquals(pscDiscrepancy.getDetails(), response.getBody().getSuccessBody().getDetails());
+        assertEquals(pscDiscrepancy.getEtag(), response.getBody().getSuccessBody().getEtag());
+        assertEquals(pscDiscrepancy.getKind(), response.getBody().getSuccessBody().getKind());
+        assertEquals(pscDiscrepancy.getLinks(), response.getBody().getSuccessBody().getLinks());
     }
     
-    @DisplayName("When getDiscrepancy returns an invalid ServiceResult then a Bad Request is returned with an error body")
-    void getDiscrepancyReturnsValidationServiceResult() {
+    @Test
+    @DisplayName("When getDiscrepancy cannot find discrepancy returns Not Found and no response body")
+    void getDiscrepancyUnsuccessful() throws ServiceException {
+        ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.notFound();
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenReturn(serviceResult);
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
+                pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         
+        assertNotNull(response);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
     }
-    
+
+    @Test
+    @DisplayName("When getDiscrepancy returns an invalid ServiceResult returns Bad Request response along with an error body")
+    void getDiscrepancyReturnsValidationServiceResult() throws ServiceException {
+        Errors errData = createErrors(DISCREPANCY_DETAILS_ID, MUST_NOT_BE_NULL);
+        ServiceResult<PscDiscrepancy> serviceResult = ServiceResult.invalid(errData);
+        
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenReturn(serviceResult);
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
+                pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(response.getBody().getErrorBody().hasErrors());
+    }
+
+    @Test
     @DisplayName("When getDiscrepancy throws a ServiceException then an Internal Server Error response is returned")
-    void getDiscrepancyThrowsServiceException() {
+    void getDiscrepancyThrowsServiceException() throws ServiceException {
+        when(pscDiscrepancyService.getDiscrepancy(DISCREPANCY_DETAILS_ID)).thenThrow(new ServiceException(""));
+        ResponseEntity<ChResponseBody<PscDiscrepancy>> response = 
+                pscDiscrepancyController.getDiscrepancy(DISCREPANCY_REPORT_ID, DISCREPANCY_DETAILS_ID, request);
         
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
     }
-    
+
+    @Test
     @DisplayName("When getDiscrepancies successfully returns a service response of a list of discrepancies")
-    void getDiscrepanciesSuccessful() {
+    void getDiscrepanciesSuccessful() throws ServiceException {
+        List<PscDiscrepancy> discrepancies = new ArrayList<>();
+        pscDiscrepancy = populatePscDiscrepancy();
+        discrepancies.add(pscDiscrepancy);
+        ServiceResult<List<PscDiscrepancy>> serviceResult = ServiceResult.found(discrepancies);
         
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenReturn(serviceResult);
+        
+        ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
+                pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
+        
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(discrepancies, response.getBody().getSuccessBody());
     }
     
+    @Test
+    @DisplayName("When getDiscrepancies is unsuccessful returns a service response with not found status")
+    void getDiscrepanciesUnsuccessful() throws ServiceException {
+        ServiceResult<List<PscDiscrepancy>> serviceResult = ServiceResult.notFound();
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenReturn(serviceResult);
+        
+        ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
+                pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
+        
+        assertNotNull(response);
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertNull(response.getBody());
+    }
+
+    @Test
     @DisplayName("When getDiscrepancies returns an invalid ServiceResult then a Bad Request is returned with an error body")
-    void getDiscrepanciesReturnValidationServiceResult() {
+    void getDiscrepanciesReturnValidationServiceResult() throws ServiceException {
+        Errors errData = createErrors(DISCREPANCY_DETAILS_ID, MUST_NOT_BE_NULL);
+        ServiceResult<List<PscDiscrepancy>> serviceResult = ServiceResult.invalid(errData);
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenReturn(serviceResult);
         
+        ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
+                pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
+        
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertTrue(response.getBody().getErrorBody().hasErrors());
+    }
+
+    @Test
+    @DisplayName("When getDiscrepancies throws a ServiceException then an Internal Server Error response is returned")
+    void getDiscrepanciesThrowsServiceException() throws ServiceException {
+        when(pscDiscrepancyService.getDiscrepancies(DISCREPANCY_REPORT_ID)).thenThrow(new ServiceException(""));
+        ResponseEntity<ChResponseBody<List<PscDiscrepancy>>> response = 
+                pscDiscrepancyController.getDiscrepancies(DISCREPANCY_REPORT_ID, request);
+        
+        assertNotNull(response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertNull(response.getBody());
     }
     
-    @DisplayName("When getDiscrepancies throws a ServiceException then an Internal Server Error response is returned")
-    void getDiscrepanciesThrowsServiceException() {
-        
+    private PscDiscrepancy populatePscDiscrepancy() {
+        pscDiscrepancy.setDetails(DISCREPANCY_DETAILS);
+        pscDiscrepancy.setEtag("etag");
+        pscDiscrepancy.setKind("kind");
+        Links links = new Links();
+        Map<String, String> map = new HashMap<>();
+        map.put("self", SELF_LINK);
+        map.put("psc-discrepancy-report", REPORT_SELF_LINK);
+        links.setLinks(map);
+        pscDiscrepancy.setLinks(links);
+        return pscDiscrepancy;
+    }
+    
+    private Errors createErrors(String field, String message) {
+        Errors errors = new Errors();
+        Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
+        errors.addError(error);
+        return errors;
     }
 }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -275,6 +275,24 @@ public class PscDiscrepancyServiceUnitTest {
         when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenThrow(new MongoException(""));
         assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID));
     }
+    
+    @Test
+    @DisplayName("Test createDebugMapWithoutDiscrepancyObject returns a Map with discrepancy report id and discrepancy id entries")
+    void createDebugMapWithoutDiscrepancyObjectReturnsMap() {
+        Map<String, Object> returnedMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject("123", "456");
+        assertTrue(returnedMap.size() == 2);
+        assertEquals(returnedMap.get(REPORT_ID), "123");
+        assertEquals(returnedMap.get(DISCREPANCY_ID), "456");
+        
+    }
+    
+    @Test
+    @DisplayName("Test createDebugMapWithoutDiscrepancyObject returns a Map with discrepancy report id entry")
+    void createDebugMapWithoutDiscrepancyObjectWithNullDiscrepancyDetailsId() {
+        Map<String, Object> returnedMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject("123", null);
+        assertTrue(returnedMap.size() == 1);
+        assertEquals(returnedMap.get(REPORT_ID), "123");
+    }
 
     private PscDiscrepancy createTestDiscrepancy(String details, String etag, String kind) {
         PscDiscrepancy pscDiscrepancy = new PscDiscrepancy();

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -120,7 +120,7 @@ public class PscDiscrepancyServiceUnitTest {
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
-        assertTrue(result.getErrors().containsError(error)); s
+        assertTrue(result.getErrors().containsError(error));
     }
 
     @Test

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -115,12 +115,12 @@ public class PscDiscrepancyServiceUnitTest {
                 .withError(DISCREPANCY_DETAILS + " must not be null").build();
         errData.addError(error);
 
-        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
-                request);
+        ServiceResult<PscDiscrepancy> result = 
+                pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
-        assertTrue(result.getErrors().containsError(error));
+        assertTrue(result.getErrors().containsError(error)); s
     }
 
     @Test
@@ -275,7 +275,7 @@ public class PscDiscrepancyServiceUnitTest {
         when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenThrow(new MongoException(""));
         assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID));
     }
-    
+
     @Test
     @DisplayName("Test createDebugMapWithoutDiscrepancyObject returns a Map with discrepancy report id and discrepancy id entries")
     void createDebugMapWithoutDiscrepancyObjectReturnsMap() {
@@ -283,9 +283,9 @@ public class PscDiscrepancyServiceUnitTest {
         assertTrue(returnedMap.size() == 2);
         assertEquals(returnedMap.get(REPORT_ID), "123");
         assertEquals(returnedMap.get(DISCREPANCY_ID), "456");
-        
+
     }
-    
+
     @Test
     @DisplayName("Test createDebugMapWithoutDiscrepancyObject returns a Map with discrepancy report id entry")
     void createDebugMapWithoutDiscrepancyObjectWithNullDiscrepancyDetailsId() {

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -259,9 +259,10 @@ public class PscDiscrepancyServiceUnitTest {
     }
 
     @Test
-    @DisplayName("Test getDiscrepancy repository returns null should return not found")
+    @DisplayName("Test getDiscrepancy repository returns nno discrepancy should return not found")
     void getDiscrepancyNullListReturnsNotFound() throws ServiceException {
-        when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(null);
+        Optional<PscDiscrepancyEntity> optionalEntity = Optional.empty();
+        when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(optionalEntity);
 
         ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(REPORT_ID, DISCREPANCY_ID, request);
 

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -154,7 +154,7 @@ public class PscDiscrepancyServiceUnitTest {
         when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(pscDiscrepancyEntityList);
         when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntityList.get(0))).thenReturn(pscDiscrepancy);
 
-        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID, request);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.FOUND, result.getStatus());
@@ -165,7 +165,7 @@ public class PscDiscrepancyServiceUnitTest {
     @Test
     @DisplayName("Test getDiscrepancies using null report id returns invalid")
     void getDiscrepanciesNullIdReturnsInvalid() throws ServiceException {
-        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(null);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(null, request);
 
         Err error = createErrors(REPORT_ID, " must not be null");
 
@@ -177,7 +177,7 @@ public class PscDiscrepancyServiceUnitTest {
     @Test
     @DisplayName("Test getDiscrepancies using empty String report id returns invalid")
     void getDiscrepanciesEmptyReportIdReturnsInvalid() throws ServiceException {
-        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies("");
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies("", request);
 
         Err error = createErrors(REPORT_ID, " must not be null");
 
@@ -192,7 +192,7 @@ public class PscDiscrepancyServiceUnitTest {
 
         when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(null);
 
-        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID, request);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
@@ -203,7 +203,7 @@ public class PscDiscrepancyServiceUnitTest {
     void getDiscrepanciesEmptyListReturnsNotFound() throws ServiceException {
         when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(new ArrayList<PscDiscrepancyEntity>());
 
-        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID, request);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
@@ -213,7 +213,7 @@ public class PscDiscrepancyServiceUnitTest {
     @DisplayName("Test getDiscrepancies repository throws a MongoException which throws a ServiceException")
     void getDiscrepanciesMongoExceptionThrowsServiceException() {
         when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenThrow(new MongoException(""));
-        assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancies(REPORT_ID));
+        assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancies(REPORT_ID, request));
 
     }
 
@@ -227,7 +227,7 @@ public class PscDiscrepancyServiceUnitTest {
         when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(optionalEntity);
         when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
 
-        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(REPORT_ID, DISCREPANCY_ID, request);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.FOUND, result.getStatus());
@@ -237,7 +237,7 @@ public class PscDiscrepancyServiceUnitTest {
     @Test
     @DisplayName("Test getDiscrepancy using null discrepancy id returns invalid")
     void getDiscrepancyNullIdReturnsInvalid() throws ServiceException {
-        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(null);
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(REPORT_ID, null, request);
 
         Err error = createErrors(DISCREPANCY_ID, " must not be null");
 
@@ -249,7 +249,7 @@ public class PscDiscrepancyServiceUnitTest {
     @Test
     @DisplayName("Test getDiscrepancy using empty String discrepancy id returns invalid")
     void getDiscrepancyEmptyReportIdReturnsInvalid() throws ServiceException {
-        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy("");
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(REPORT_ID, "", request);
 
         Err error = createErrors(DISCREPANCY_ID, " must not be null");
 
@@ -263,7 +263,7 @@ public class PscDiscrepancyServiceUnitTest {
     void getDiscrepancyNullListReturnsNotFound() throws ServiceException {
         when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(null);
 
-        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(REPORT_ID, DISCREPANCY_ID, request);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
@@ -273,7 +273,7 @@ public class PscDiscrepancyServiceUnitTest {
     @DisplayName("Test getDiscrepancy repository throws a MongoException which throws a ServiceException")
     void getDiscrepancyMongoExceptionThrowsServiceException() {
         when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenThrow(new MongoException(""));
-        assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID));
+        assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(REPORT_ID, DISCREPANCY_ID, request));
     }
 
     @Test
@@ -281,8 +281,8 @@ public class PscDiscrepancyServiceUnitTest {
     void createDebugMapWithoutDiscrepancyObjectReturnsMap() {
         Map<String, Object> returnedMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject("123", "456");
         assertTrue(returnedMap.size() == 2);
-        assertEquals(returnedMap.get(REPORT_ID), "123");
-        assertEquals(returnedMap.get(DISCREPANCY_ID), "456");
+        assertEquals("123", returnedMap.get(REPORT_ID));
+        assertEquals("456", returnedMap.get(DISCREPANCY_ID));
 
     }
 
@@ -291,7 +291,7 @@ public class PscDiscrepancyServiceUnitTest {
     void createDebugMapWithoutDiscrepancyObjectWithNullDiscrepancyDetailsId() {
         Map<String, Object> returnedMap = pscDiscrepancyService.createDebugMapWithoutDiscrepancyObject("123", null);
         assertTrue(returnedMap.size() == 1);
-        assertEquals(returnedMap.get(REPORT_ID), "123");
+        assertEquals("123", returnedMap.get(REPORT_ID));
     }
 
     private PscDiscrepancy createTestDiscrepancy(String details, String etag, String kind) {

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -7,6 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,108 +27,291 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.mongodb.MongoException;
 
 import uk.gov.ch.pscdiscrepanciesapi.common.LinkFactory;
+import uk.gov.ch.pscdiscrepanciesapi.common.PscDiscrepancyLinkKeys;
 import uk.gov.ch.pscdiscrepanciesapi.mappers.PscDiscrepancyMapper;
-import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntityData;
 import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntity;
+import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntityData;
 import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancy;
 import uk.gov.ch.pscdiscrepanciesapi.repositories.PscDiscrepancyRepository;
 import uk.gov.companieshouse.service.ServiceException;
 import uk.gov.companieshouse.service.ServiceResult;
 import uk.gov.companieshouse.service.ServiceResultStatus;
+import uk.gov.companieshouse.service.links.Links;
 import uk.gov.companieshouse.service.rest.err.Err;
 import uk.gov.companieshouse.service.rest.err.Errors;
 
 @ExtendWith(MockitoExtension.class)
 public class PscDiscrepancyServiceUnitTest {
 
-    private static final String REPORT_ID = "reportId";
-    private static final String DISCREPANCY_ID = "discrepancyId";
-    private static final String DETAILS_DATA = "some details";
-    private static final String SELF_LINK = "/parent/" + REPORT_ID + "/self/" + DISCREPANCY_ID;
-    private static final String PARENT_LINK = "/parent/" + REPORT_ID;
-    private static final String DISCREPANCY_DETAILS = "details";
+	private static final String REPORT_ID = "discrepancy-report-id";
+	private static final String DISCREPANCY_ID = "discrepancy-id";
+	private static final String DETAILS_DATA = "some details";
+	private static final String SELF_LINK = "/psc-discrepancy-reports/" + REPORT_ID + "/discrepancies/"
+	        + DISCREPANCY_ID;
+	private static final String PARENT_LINK = "/psc-discrepancy-reports/" + REPORT_ID;
+	private static final String DISCREPANCY_DETAILS = "details";
+	private static final String KIND = "kind";
+	private static final String ETAG = "etag";
+	private static final int YEAR = 2020;
+	private static final int MONTH = 1;
+	private static final int DAY = 1;
 
-    private PscDiscrepancy pscDiscrepancy;
-    private PscDiscrepancyEntity pscDiscrepancyEntity;
+	private PscDiscrepancy pscDiscrepancy;
+	private PscDiscrepancyEntity pscDiscrepancyEntity;
+	private List<PscDiscrepancyEntity> pscDiscrepancyEntityList;
+	private List<PscDiscrepancy> pscDiscrepancyList;
 
-    @Mock
-    private PscDiscrepancyMapper mockDiscrepancyMapper;
+	@Mock
+	private PscDiscrepancyMapper mockDiscrepancyMapper;
 
-    @Mock
-    private PscDiscrepancyRepository mockDiscrepancyRepo;
+	@Mock
+	private PscDiscrepancyRepository mockDiscrepancyRepo;
 
-    @Mock
-    private HttpServletRequest request;
-    
-    @Mock
-    private LinkFactory linkFactory;
+	@Mock
+	private HttpServletRequest request;
 
-    @InjectMocks
-    private PscDiscrepancyService pscDiscrepancyService;
+	@Mock
+	private LinkFactory linkFactory;
 
-    @BeforeEach
-    void setUp() {
-        pscDiscrepancy = new PscDiscrepancy();
-        pscDiscrepancyEntity = new PscDiscrepancyEntity();
-    }
+	@InjectMocks
+	private PscDiscrepancyService pscDiscrepancyService;
 
-    @Test
-    @DisplayName("Test createPscDiscrepancy is successful")
-    void createPscDiscrepancySuccessful() throws ServiceException {
-        
-        pscDiscrepancy.setDetails(DETAILS_DATA);
-        PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
-        pscDiscrepancyData.setDetails(DETAILS_DATA);
-        pscDiscrepancyEntity.setData(pscDiscrepancyData);
+	@BeforeEach
+	void setUp() {
+		pscDiscrepancy = new PscDiscrepancy();
+		pscDiscrepancyEntity = new PscDiscrepancyEntity();
+	}
 
-        when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
-        when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
-        		
-        when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenReturn(pscDiscrepancyEntity);
-        when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
-        when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
+	@Test
+	@DisplayName("Test createPscDiscrepancy is successful")
+	void createPscDiscrepancySuccessful() throws ServiceException {
 
-        ServiceResult<PscDiscrepancy> result =
-                pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request);
+		pscDiscrepancy.setDetails(DETAILS_DATA);
+		PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
+		pscDiscrepancyData.setDetails(DETAILS_DATA);
+		pscDiscrepancyEntity.setData(pscDiscrepancyData);
+
+		when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
+		when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
+
+		when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenReturn(pscDiscrepancyEntity);
+		when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
+		when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
+
+		ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
+		        request);
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.CREATED, result.getStatus());
+		assertEquals(pscDiscrepancy, result.getData());
+	}
+
+	@Test
+	@DisplayName("Test createPscDiscrepancy returns an invalid ServiceResult")
+	void createPscDiscrepancyReturnsInvalidServiceResult() throws ServiceException {
+
+		Errors errData = new Errors();
+		Err error = Err.invalidBodyBuilderWithLocation(DISCREPANCY_DETAILS)
+		        .withError(DISCREPANCY_DETAILS + " must not be null").build();
+		errData.addError(error);
+
+		ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
+		        request);
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+		assertTrue(result.getErrors().containsError(error));
+	}
+
+	@Test
+	@DisplayName("Test createPscDiscrepancy throws ServiceExeption")
+	void createPscDiscrepancyThrowsServiceException() {
+
+		pscDiscrepancy.setDetails(DETAILS_DATA);
+		PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
+		pscDiscrepancyData.setDetails(DETAILS_DATA);
+		pscDiscrepancyEntity.setData(pscDiscrepancyData);
+
+		when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
+		when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
+
+		when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenThrow(new MongoException(""));
+		when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
+
+		assertThrows(ServiceException.class,
+		        () -> pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request));
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancies returns a list of discrepancies")
+	void getDiscrepanciesIsSuccessful() throws ServiceException {
+		pscDiscrepancyEntityList = new ArrayList<>();
+		pscDiscrepancyEntityList.add(createTestDiscrepancyEntity(DETAILS_DATA, ETAG, KIND));
+		pscDiscrepancy = createTestDiscrepancy(DETAILS_DATA, ETAG, KIND);
+		pscDiscrepancyList = new ArrayList<>();
+		pscDiscrepancyList.add(pscDiscrepancy);
+
+		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(pscDiscrepancyEntityList);
+		when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntityList.get(0))).thenReturn(pscDiscrepancy);
+
+		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.FOUND, result.getStatus());
+		assertEquals(pscDiscrepancyList, result.getData());
+
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancies using null report id returns invalid")
+	void getDiscrepanciesNullIdReturnsInvalid() throws ServiceException {
+		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(null);
+
+		Err error = createErrors(REPORT_ID, " must not be null");
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+		assertTrue(result.getErrors().containsError(error));
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancies using empty String report id returns invalid")
+	void getDiscrepanciesEmptyReportIdReturnsInvalid() throws ServiceException {
+		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies("");
+
+		Err error = createErrors(REPORT_ID, " must not be null");
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+		assertTrue(result.getErrors().containsError(error));
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancies repository returns null list which returns not found")
+	void getDiscrepanciesNullListReturnsNotFound() throws ServiceException {
+
+		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(null);
+
+		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancies repository returns empty list which returns not found")
+	void getDiscrepanciesEmptyListReturnsNotFound() throws ServiceException {
+		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(new ArrayList<PscDiscrepancyEntity>());
+
+		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancies repository throws a MongoException which throws a ServiceException")
+	void getDiscrepanciesMongoExceptionThrowsServiceException() {
+		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenThrow(new MongoException(""));
+		assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancies(REPORT_ID));
+
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancy returns a discrepancy")
+	void getDiscrepancyIsSuccessful() throws ServiceException {
+		pscDiscrepancyEntity = createTestDiscrepancyEntity(DETAILS_DATA, ETAG, KIND);
+		pscDiscrepancy = createTestDiscrepancy(DETAILS_DATA, ETAG, KIND);
+		Optional<PscDiscrepancyEntity> optionalEntity = Optional.of(pscDiscrepancyEntity);
+		
+		when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(optionalEntity);
+		when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
+		
+		ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
 
         assertNotNull(result);
-        assertEquals(ServiceResultStatus.CREATED, result.getStatus());
+        assertEquals(ServiceResultStatus.FOUND, result.getStatus());
         assertEquals(pscDiscrepancy, result.getData());
-    }
+	}
 
-    @Test
-    @DisplayName("Test createPscDiscrepancy returns an invalid ServiceResult")
-    void createPscDiscrepancyReturnsInvalidServiceResult() throws ServiceException {
+	@Test
+	@DisplayName("Test getDiscrepancy using null discrepancy id returns invalid")
+	void getDiscrepancyNullIdReturnsInvalid() throws ServiceException {
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(null);
 
-        Errors errData = new Errors();
-        Err error = Err.invalidBodyBuilderWithLocation(DISCREPANCY_DETAILS)
-                .withError(DISCREPANCY_DETAILS + " must not be null").build();
-        errData.addError(error);
+		Err error = createErrors(DISCREPANCY_ID, " must not be null");
 
-        ServiceResult<PscDiscrepancy> result =
-                pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request);
+		assertNotNull(result);
+		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+		assertTrue(result.getErrors().containsError(error));
+	}
+
+	@Test
+	@DisplayName("Test getDiscrepancy using empty String discrepancy id returns invalid")
+	void getDiscrepancyEmptyReportIdReturnsInvalid() throws ServiceException {
+	    ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy("");
+
+        Err error = createErrors(DISCREPANCY_ID, " must not be null");
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
         assertTrue(result.getErrors().containsError(error));
-    }
+	}
 
-    @Test
-    @DisplayName("Test createPscDiscrepancy throws ServiceExeption")
-    void createPscDiscrepancyThrowsServiceException() {
-        
-        pscDiscrepancy.setDetails(DETAILS_DATA);
-        PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
-        pscDiscrepancyData.setDetails(DETAILS_DATA);
-        pscDiscrepancyEntity.setData(pscDiscrepancyData);
+	@Test
+	@DisplayName("Test getDiscrepancy repository returns null should return not found")
+	void getDiscrepancyNullListReturnsNotFound() throws ServiceException {
+	    when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(null);
+	    
+	    ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
+	    
+	    assertNotNull(result);
+        assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
+	}
 
-        when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
-        when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
+	@Test
+	@DisplayName("Test getDiscrepancy repository throws a MongoException which throws a ServiceException")
+	void getDiscrepancyMongoExceptionThrowsServiceException() {
+		when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenThrow(new MongoException(""));
+		assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID));
+	}
 
-        when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenThrow(new MongoException(""));
-        when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
+	private PscDiscrepancy createTestDiscrepancy(String details, String etag, String kind) {
+		PscDiscrepancy pscDiscrepancy = new PscDiscrepancy();
+		pscDiscrepancy.setDetails(details);
+		pscDiscrepancy.setEtag(etag);
+		pscDiscrepancy.setKind(kind);
+		return pscDiscrepancy;
+	}
 
-        assertThrows(ServiceException.class, () -> pscDiscrepancyService
-                .createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request));
-    }
+	private PscDiscrepancyEntity createTestDiscrepancyEntity(String details, String etag, String kind) {
+		PscDiscrepancyEntity pscDiscrepancyEntity = new PscDiscrepancyEntity();
+		pscDiscrepancyEntity.setCreatedAt(LocalDateTime.of(YEAR, MONTH, DAY, 0, 0, 0, 0));
+		pscDiscrepancyEntity.setId(DISCREPANCY_ID);
+
+		PscDiscrepancyEntityData pscDiscrepancyEntityData = new PscDiscrepancyEntityData();
+		pscDiscrepancyEntityData.setDetails(details);
+		pscDiscrepancyEntityData.setEtag(etag);
+		pscDiscrepancyEntityData.setKind(kind);
+		pscDiscrepancyEntityData.setLinks(createLinks());
+		pscDiscrepancyEntity.setData(pscDiscrepancyEntityData);
+
+		pscDiscrepancyEntity.setData(pscDiscrepancyEntityData);
+
+		return pscDiscrepancyEntity;
+	}
+
+	private Links createLinks() {
+		Links links = new Links();
+		Map<String, String> linksMap = new HashMap<String, String>();
+		linksMap.put("self", SELF_LINK);
+		linksMap.put(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT.toString(), PARENT_LINK);
+		links.setLinks(linksMap);
+		return links;
+	}
+
+	private Err createErrors(String field, String message) {
+		Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
+		return error;
+	}
 }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -43,275 +43,275 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 @ExtendWith(MockitoExtension.class)
 public class PscDiscrepancyServiceUnitTest {
 
-	private static final String REPORT_ID = "discrepancy-report-id";
-	private static final String DISCREPANCY_ID = "discrepancy-id";
-	private static final String DETAILS_DATA = "some details";
-	private static final String SELF_LINK = "/psc-discrepancy-reports/" + REPORT_ID + "/discrepancies/"
-	        + DISCREPANCY_ID;
-	private static final String PARENT_LINK = "/psc-discrepancy-reports/" + REPORT_ID;
-	private static final String DISCREPANCY_DETAILS = "details";
-	private static final String KIND = "kind";
-	private static final String ETAG = "etag";
-	private static final int YEAR = 2020;
-	private static final int MONTH = 1;
-	private static final int DAY = 1;
+    private static final String REPORT_ID = "discrepancy-report-id";
+    private static final String DISCREPANCY_ID = "discrepancy-id";
+    private static final String DETAILS_DATA = "some details";
+    private static final String SELF_LINK = "/psc-discrepancy-reports/" + REPORT_ID + "/discrepancies/"
+            + DISCREPANCY_ID;
+    private static final String PARENT_LINK = "/psc-discrepancy-reports/" + REPORT_ID;
+    private static final String DISCREPANCY_DETAILS = "details";
+    private static final String KIND = "kind";
+    private static final String ETAG = "etag";
+    private static final int YEAR = 2020;
+    private static final int MONTH = 1;
+    private static final int DAY = 1;
 
-	private PscDiscrepancy pscDiscrepancy;
-	private PscDiscrepancyEntity pscDiscrepancyEntity;
-	private List<PscDiscrepancyEntity> pscDiscrepancyEntityList;
-	private List<PscDiscrepancy> pscDiscrepancyList;
+    private PscDiscrepancy pscDiscrepancy;
+    private PscDiscrepancyEntity pscDiscrepancyEntity;
+    private List<PscDiscrepancyEntity> pscDiscrepancyEntityList;
+    private List<PscDiscrepancy> pscDiscrepancyList;
 
-	@Mock
-	private PscDiscrepancyMapper mockDiscrepancyMapper;
+    @Mock
+    private PscDiscrepancyMapper mockDiscrepancyMapper;
 
-	@Mock
-	private PscDiscrepancyRepository mockDiscrepancyRepo;
+    @Mock
+    private PscDiscrepancyRepository mockDiscrepancyRepo;
 
-	@Mock
-	private HttpServletRequest request;
+    @Mock
+    private HttpServletRequest request;
 
-	@Mock
-	private LinkFactory linkFactory;
+    @Mock
+    private LinkFactory linkFactory;
 
-	@InjectMocks
-	private PscDiscrepancyService pscDiscrepancyService;
+    @InjectMocks
+    private PscDiscrepancyService pscDiscrepancyService;
 
-	@BeforeEach
-	void setUp() {
-		pscDiscrepancy = new PscDiscrepancy();
-		pscDiscrepancyEntity = new PscDiscrepancyEntity();
-	}
+    @BeforeEach
+    void setUp() {
+        pscDiscrepancy = new PscDiscrepancy();
+        pscDiscrepancyEntity = new PscDiscrepancyEntity();
+    }
 
-	@Test
-	@DisplayName("Test createPscDiscrepancy is successful")
-	void createPscDiscrepancySuccessful() throws ServiceException {
+    @Test
+    @DisplayName("Test createPscDiscrepancy is successful")
+    void createPscDiscrepancySuccessful() throws ServiceException {
 
-		pscDiscrepancy.setDetails(DETAILS_DATA);
-		PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
-		pscDiscrepancyData.setDetails(DETAILS_DATA);
-		pscDiscrepancyEntity.setData(pscDiscrepancyData);
+        pscDiscrepancy.setDetails(DETAILS_DATA);
+        PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
+        pscDiscrepancyData.setDetails(DETAILS_DATA);
+        pscDiscrepancyEntity.setData(pscDiscrepancyData);
 
-		when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
-		when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
+        when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
+        when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
 
-		when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenReturn(pscDiscrepancyEntity);
-		when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
-		when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
+        when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenReturn(pscDiscrepancyEntity);
+        when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
+        when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
 
-		ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
-		        request);
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
+                request);
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.CREATED, result.getStatus());
-		assertEquals(pscDiscrepancy, result.getData());
-	}
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.CREATED, result.getStatus());
+        assertEquals(pscDiscrepancy, result.getData());
+    }
 
-	@Test
-	@DisplayName("Test createPscDiscrepancy returns an invalid ServiceResult")
-	void createPscDiscrepancyReturnsInvalidServiceResult() throws ServiceException {
+    @Test
+    @DisplayName("Test createPscDiscrepancy returns an invalid ServiceResult")
+    void createPscDiscrepancyReturnsInvalidServiceResult() throws ServiceException {
 
-		Errors errData = new Errors();
-		Err error = Err.invalidBodyBuilderWithLocation(DISCREPANCY_DETAILS)
-		        .withError(DISCREPANCY_DETAILS + " must not be null").build();
-		errData.addError(error);
+        Errors errData = new Errors();
+        Err error = Err.invalidBodyBuilderWithLocation(DISCREPANCY_DETAILS)
+                .withError(DISCREPANCY_DETAILS + " must not be null").build();
+        errData.addError(error);
 
-		ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
-		        request);
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID,
+                request);
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
-		assertTrue(result.getErrors().containsError(error));
-	}
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+        assertTrue(result.getErrors().containsError(error));
+    }
 
-	@Test
-	@DisplayName("Test createPscDiscrepancy throws ServiceExeption")
-	void createPscDiscrepancyThrowsServiceException() {
+    @Test
+    @DisplayName("Test createPscDiscrepancy throws ServiceExeption")
+    void createPscDiscrepancyThrowsServiceException() {
 
-		pscDiscrepancy.setDetails(DETAILS_DATA);
-		PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
-		pscDiscrepancyData.setDetails(DETAILS_DATA);
-		pscDiscrepancyEntity.setData(pscDiscrepancyData);
+        pscDiscrepancy.setDetails(DETAILS_DATA);
+        PscDiscrepancyEntityData pscDiscrepancyData = new PscDiscrepancyEntityData();
+        pscDiscrepancyData.setDetails(DETAILS_DATA);
+        pscDiscrepancyEntity.setData(pscDiscrepancyData);
 
-		when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
-		when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
+        when(linkFactory.createLinkPscDiscrepancy(anyString(), anyString())).thenReturn(SELF_LINK);
+        when(linkFactory.createLinkPscDiscrepancyReport(REPORT_ID)).thenReturn(PARENT_LINK);
 
-		when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenThrow(new MongoException(""));
-		when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
+        when(mockDiscrepancyRepo.insert(pscDiscrepancyEntity)).thenThrow(new MongoException(""));
+        when(mockDiscrepancyMapper.restToEntity(pscDiscrepancy)).thenReturn(pscDiscrepancyEntity);
 
-		assertThrows(ServiceException.class,
-		        () -> pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request));
-	}
+        assertThrows(ServiceException.class,
+                () -> pscDiscrepancyService.createPscDiscrepancy(pscDiscrepancy, REPORT_ID, request));
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancies returns a list of discrepancies")
-	void getDiscrepanciesIsSuccessful() throws ServiceException {
-		pscDiscrepancyEntityList = new ArrayList<>();
-		pscDiscrepancyEntityList.add(createTestDiscrepancyEntity(DETAILS_DATA, ETAG, KIND));
-		pscDiscrepancy = createTestDiscrepancy(DETAILS_DATA, ETAG, KIND);
-		pscDiscrepancyList = new ArrayList<>();
-		pscDiscrepancyList.add(pscDiscrepancy);
+    @Test
+    @DisplayName("Test getDiscrepancies returns a list of discrepancies")
+    void getDiscrepanciesIsSuccessful() throws ServiceException {
+        pscDiscrepancyEntityList = new ArrayList<>();
+        pscDiscrepancyEntityList.add(createTestDiscrepancyEntity(DETAILS_DATA, ETAG, KIND));
+        pscDiscrepancy = createTestDiscrepancy(DETAILS_DATA, ETAG, KIND);
+        pscDiscrepancyList = new ArrayList<>();
+        pscDiscrepancyList.add(pscDiscrepancy);
 
-		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(pscDiscrepancyEntityList);
-		when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntityList.get(0))).thenReturn(pscDiscrepancy);
+        when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(pscDiscrepancyEntityList);
+        when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntityList.get(0))).thenReturn(pscDiscrepancy);
 
-		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.FOUND, result.getStatus());
-		assertEquals(pscDiscrepancyList, result.getData());
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.FOUND, result.getStatus());
+        assertEquals(pscDiscrepancyList, result.getData());
 
-	}
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancies using null report id returns invalid")
-	void getDiscrepanciesNullIdReturnsInvalid() throws ServiceException {
-		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(null);
+    @Test
+    @DisplayName("Test getDiscrepancies using null report id returns invalid")
+    void getDiscrepanciesNullIdReturnsInvalid() throws ServiceException {
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(null);
 
-		Err error = createErrors(REPORT_ID, " must not be null");
+        Err error = createErrors(REPORT_ID, " must not be null");
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
-		assertTrue(result.getErrors().containsError(error));
-	}
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+        assertTrue(result.getErrors().containsError(error));
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancies using empty String report id returns invalid")
-	void getDiscrepanciesEmptyReportIdReturnsInvalid() throws ServiceException {
-		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies("");
+    @Test
+    @DisplayName("Test getDiscrepancies using empty String report id returns invalid")
+    void getDiscrepanciesEmptyReportIdReturnsInvalid() throws ServiceException {
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies("");
 
-		Err error = createErrors(REPORT_ID, " must not be null");
+        Err error = createErrors(REPORT_ID, " must not be null");
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
-		assertTrue(result.getErrors().containsError(error));
-	}
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+        assertTrue(result.getErrors().containsError(error));
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancies repository returns null list which returns not found")
-	void getDiscrepanciesNullListReturnsNotFound() throws ServiceException {
+    @Test
+    @DisplayName("Test getDiscrepancies repository returns null list which returns not found")
+    void getDiscrepanciesNullListReturnsNotFound() throws ServiceException {
 
-		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(null);
+        when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(null);
 
-		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
-	}
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancies repository returns empty list which returns not found")
-	void getDiscrepanciesEmptyListReturnsNotFound() throws ServiceException {
-		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(new ArrayList<PscDiscrepancyEntity>());
+    @Test
+    @DisplayName("Test getDiscrepancies repository returns empty list which returns not found")
+    void getDiscrepanciesEmptyListReturnsNotFound() throws ServiceException {
+        when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenReturn(new ArrayList<PscDiscrepancyEntity>());
 
-		ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
+        ServiceResult<List<PscDiscrepancy>> result = pscDiscrepancyService.getDiscrepancies(REPORT_ID);
 
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
-	}
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancies repository throws a MongoException which throws a ServiceException")
-	void getDiscrepanciesMongoExceptionThrowsServiceException() {
-		when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenThrow(new MongoException(""));
-		assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancies(REPORT_ID));
+    @Test
+    @DisplayName("Test getDiscrepancies repository throws a MongoException which throws a ServiceException")
+    void getDiscrepanciesMongoExceptionThrowsServiceException() {
+        when(mockDiscrepancyRepo.getDiscrepancies(PARENT_LINK)).thenThrow(new MongoException(""));
+        assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancies(REPORT_ID));
 
-	}
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancy returns a discrepancy")
-	void getDiscrepancyIsSuccessful() throws ServiceException {
-		pscDiscrepancyEntity = createTestDiscrepancyEntity(DETAILS_DATA, ETAG, KIND);
-		pscDiscrepancy = createTestDiscrepancy(DETAILS_DATA, ETAG, KIND);
-		Optional<PscDiscrepancyEntity> optionalEntity = Optional.of(pscDiscrepancyEntity);
-		
-		when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(optionalEntity);
-		when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
-		
-		ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
+    @Test
+    @DisplayName("Test getDiscrepancy returns a discrepancy")
+    void getDiscrepancyIsSuccessful() throws ServiceException {
+        pscDiscrepancyEntity = createTestDiscrepancyEntity(DETAILS_DATA, ETAG, KIND);
+        pscDiscrepancy = createTestDiscrepancy(DETAILS_DATA, ETAG, KIND);
+        Optional<PscDiscrepancyEntity> optionalEntity = Optional.of(pscDiscrepancyEntity);
+
+        when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(optionalEntity);
+        when(mockDiscrepancyMapper.entityToRest(pscDiscrepancyEntity)).thenReturn(pscDiscrepancy);
+
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.FOUND, result.getStatus());
         assertEquals(pscDiscrepancy, result.getData());
-	}
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancy using null discrepancy id returns invalid")
-	void getDiscrepancyNullIdReturnsInvalid() throws ServiceException {
+    @Test
+    @DisplayName("Test getDiscrepancy using null discrepancy id returns invalid")
+    void getDiscrepancyNullIdReturnsInvalid() throws ServiceException {
         ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(null);
-
-		Err error = createErrors(DISCREPANCY_ID, " must not be null");
-
-		assertNotNull(result);
-		assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
-		assertTrue(result.getErrors().containsError(error));
-	}
-
-	@Test
-	@DisplayName("Test getDiscrepancy using empty String discrepancy id returns invalid")
-	void getDiscrepancyEmptyReportIdReturnsInvalid() throws ServiceException {
-	    ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy("");
 
         Err error = createErrors(DISCREPANCY_ID, " must not be null");
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
         assertTrue(result.getErrors().containsError(error));
-	}
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancy repository returns null should return not found")
-	void getDiscrepancyNullListReturnsNotFound() throws ServiceException {
-	    when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(null);
-	    
-	    ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
-	    
-	    assertNotNull(result);
+    @Test
+    @DisplayName("Test getDiscrepancy using empty String discrepancy id returns invalid")
+    void getDiscrepancyEmptyReportIdReturnsInvalid() throws ServiceException {
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy("");
+
+        Err error = createErrors(DISCREPANCY_ID, " must not be null");
+
+        assertNotNull(result);
+        assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
+        assertTrue(result.getErrors().containsError(error));
+    }
+
+    @Test
+    @DisplayName("Test getDiscrepancy repository returns null should return not found")
+    void getDiscrepancyNullListReturnsNotFound() throws ServiceException {
+        when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenReturn(null);
+
+        ServiceResult<PscDiscrepancy> result = pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID);
+
+        assertNotNull(result);
         assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
-	}
+    }
 
-	@Test
-	@DisplayName("Test getDiscrepancy repository throws a MongoException which throws a ServiceException")
-	void getDiscrepancyMongoExceptionThrowsServiceException() {
-		when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenThrow(new MongoException(""));
-		assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID));
-	}
+    @Test
+    @DisplayName("Test getDiscrepancy repository throws a MongoException which throws a ServiceException")
+    void getDiscrepancyMongoExceptionThrowsServiceException() {
+        when(mockDiscrepancyRepo.findById(DISCREPANCY_ID)).thenThrow(new MongoException(""));
+        assertThrows(ServiceException.class, () -> pscDiscrepancyService.getDiscrepancy(DISCREPANCY_ID));
+    }
 
-	private PscDiscrepancy createTestDiscrepancy(String details, String etag, String kind) {
-		PscDiscrepancy pscDiscrepancy = new PscDiscrepancy();
-		pscDiscrepancy.setDetails(details);
-		pscDiscrepancy.setEtag(etag);
-		pscDiscrepancy.setKind(kind);
-		return pscDiscrepancy;
-	}
+    private PscDiscrepancy createTestDiscrepancy(String details, String etag, String kind) {
+        PscDiscrepancy pscDiscrepancy = new PscDiscrepancy();
+        pscDiscrepancy.setDetails(details);
+        pscDiscrepancy.setEtag(etag);
+        pscDiscrepancy.setKind(kind);
+        return pscDiscrepancy;
+    }
 
-	private PscDiscrepancyEntity createTestDiscrepancyEntity(String details, String etag, String kind) {
-		PscDiscrepancyEntity pscDiscrepancyEntity = new PscDiscrepancyEntity();
-		pscDiscrepancyEntity.setCreatedAt(LocalDateTime.of(YEAR, MONTH, DAY, 0, 0, 0, 0));
-		pscDiscrepancyEntity.setId(DISCREPANCY_ID);
+    private PscDiscrepancyEntity createTestDiscrepancyEntity(String details, String etag, String kind) {
+        PscDiscrepancyEntity pscDiscrepancyEntity = new PscDiscrepancyEntity();
+        pscDiscrepancyEntity.setCreatedAt(LocalDateTime.of(YEAR, MONTH, DAY, 0, 0, 0, 0));
+        pscDiscrepancyEntity.setId(DISCREPANCY_ID);
 
-		PscDiscrepancyEntityData pscDiscrepancyEntityData = new PscDiscrepancyEntityData();
-		pscDiscrepancyEntityData.setDetails(details);
-		pscDiscrepancyEntityData.setEtag(etag);
-		pscDiscrepancyEntityData.setKind(kind);
-		pscDiscrepancyEntityData.setLinks(createLinks());
-		pscDiscrepancyEntity.setData(pscDiscrepancyEntityData);
+        PscDiscrepancyEntityData pscDiscrepancyEntityData = new PscDiscrepancyEntityData();
+        pscDiscrepancyEntityData.setDetails(details);
+        pscDiscrepancyEntityData.setEtag(etag);
+        pscDiscrepancyEntityData.setKind(kind);
+        pscDiscrepancyEntityData.setLinks(createLinks());
+        pscDiscrepancyEntity.setData(pscDiscrepancyEntityData);
 
-		pscDiscrepancyEntity.setData(pscDiscrepancyEntityData);
+        pscDiscrepancyEntity.setData(pscDiscrepancyEntityData);
 
-		return pscDiscrepancyEntity;
-	}
+        return pscDiscrepancyEntity;
+    }
 
-	private Links createLinks() {
-		Links links = new Links();
-		Map<String, String> linksMap = new HashMap<String, String>();
-		linksMap.put("self", SELF_LINK);
-		linksMap.put(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT.toString(), PARENT_LINK);
-		links.setLinks(linksMap);
-		return links;
-	}
+    private Links createLinks() {
+        Links links = new Links();
+        Map<String, String> linksMap = new HashMap<String, String>();
+        linksMap.put("self", SELF_LINK);
+        linksMap.put(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT.toString(), PARENT_LINK);
+        links.setLinks(linksMap);
+        return links;
+    }
 
-	private Err createErrors(String field, String message) {
-		Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
-		return error;
-	}
+    private Err createErrors(String field, String message) {
+        Err error = Err.invalidBodyBuilderWithLocation(field).withError(field + message).build();
+        return error;
+    }
 }


### PR DESCRIPTION
Added functionality to enable GET requests for an individual PSC Discrepancy Details and for all PSC Discrepancy Details on a particular PSC Discrepancy Report. Added unit tests to cover all new code

Added GET method for all discrepancies to PscDiscrepancyController
Added GET method for a single discrepancy to PscDiscrepancyController
Added getDiscrepancy method to PscDiscrepancyService
Added getDiscrepancies method to PscDiscrepancyService
Added method to create a debug map when there is no PscDiscrepancy object being passed in
Added method to PscDiscrepancyRepository to get all discrepancies for a report
Added unit tests to cover the above

Done as part of FAML-365