### PR TITLE
Send report to chips

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
         <org.mapstruct.version>1.3.1.Final</org.mapstruct.version>
         <rest-service-common-library-version>0.0.5</rest-service-common-library-version>
         <structured-logging.version>1.4.0-rc2</structured-logging.version>
+        <json-sanitizer.version>1.2.0</json-sanitizer.version>
+        <httpclient.version>4.5.12</httpclient.version>
+        <environment-reader-library.version>1.3.6</environment-reader-library.version>
 
         <!-- Sonar -->
         <sonar-maven-plugin.version>3.4.0.905</sonar-maven-plugin.version>
@@ -70,6 +73,22 @@
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version><!--$NO-MVN-MAN-VER$-->
+        </dependency>
+        <dependency>
+            <groupId>com.mikesamuel</groupId>
+            <artifactId>json-sanitizer</artifactId>
+            <version>${json-sanitizer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>environment-reader-library</artifactId>
+            <version>${environment-reader-library.version}</version>
+        </dependency>
+        
 
         <!-- Unit Test Dependencies -->
         <dependency>
@@ -80,6 +99,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -502,7 +502,7 @@
           },
           "status" : {
             "type" : "string",
-            "enum" : [ "INCOMPLETE", "COMPLETE", "INVALID", "SUBMITTED", "DELETED" ],
+            "enum" : [ "INCOMPLETE", "COMPLETE", "INVALID", "SUBMITTED", "DELETED", "FAILED_TO_SUBMIT" ],
             "example" : "SUBMITTED"
           },
           "links" : {

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
@@ -31,25 +31,23 @@ public class PscSubmissionSender {
 
     private static final String CHIPS_REST_INTERFACE_ENDPOINT = "CHIPS_REST_INTERFACE_ENDPOINT";
     private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final String postUrl;
     
-    private ObjectMapper objectMapper;
-
     public PscSubmissionSender() {
         this(new EnvironmentReaderImpl());
     }
 
     public PscSubmissionSender(EnvironmentReader environmentReader) {
         this.postUrl = environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT);
-        this.objectMapper = new ObjectMapper();
     }
 
     public boolean send(PscSubmission submission, CloseableHttpClient client, String requestId)
             throws ServiceException {
         try {
             submission.setRequestId(requestId);
-            String discrepancyJson = objectMapper.writeValueAsString(submission);
+            String discrepancyJson = OBJECT_MAPPER.writeValueAsString(submission);
             String sanitisedJson = JsonSanitizer.sanitize(discrepancyJson);
             StringEntity entity = new StringEntity(sanitisedJson);
             LOG.info("About to submit report: " + submission);

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
@@ -1,0 +1,76 @@
+package uk.gov.ch.pscdiscrepanciesapi.common;
+
+import java.io.IOException;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.json.JsonSanitizer;
+
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscSubmission;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
+import uk.gov.companieshouse.service.ServiceException;
+
+/**
+ * Listens for the creation of a PscDiscrepancySurvey, converts it to JSON, and sends by HTTP POST
+ * it to the supplied URL.
+ *
+ */
+@Service
+public class PscSubmissionSender {
+    
+    private static final String CHIPS_REST_INTERFACE_ENDPOINT = "CHIPS_REST_INTERFACE_ENDPOINT";
+    private static final Logger LOG = LogManager.getLogger(PscSubmissionSender.class);
+    
+    private final String postUrl;
+    
+    public PscSubmissionSender() {
+        this(new EnvironmentReaderImpl());
+    }
+    
+    public PscSubmissionSender(EnvironmentReader environmentReader) {
+        this.postUrl = environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT);
+    }
+
+    public boolean send(PscSubmission submission,CloseableHttpClient client,ObjectMapper objectMapper,String requestId) throws ServiceException {
+        try {
+            submission.setRequestId(requestId);
+            String discrepancyJson = objectMapper.writeValueAsString(submission);
+            String sanitisedJson = JsonSanitizer.sanitize(discrepancyJson);
+            StringEntity entity = new StringEntity(sanitisedJson);
+            LOG.info("Callback for discrepancy: {}", sanitisedJson);
+            HttpPost httpPost = new HttpPost(postUrl);
+            httpPost.setEntity(entity);
+            httpPost.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                if (response.getStatusLine().getStatusCode() == HttpStatus.SC_ACCEPTED) {
+                    //TODO: Use structured Logging 
+                    LOG.info("Successfully sent JSON");
+                    return true;
+                } else {
+                    //TODO: Use structured Logging 
+                    LOG.error("Failed to send JSON: {}", response);
+                    return false;
+                }
+            }
+        } catch (JsonProcessingException e) {
+            //TODO: Use structured Logging 
+            LOG.error("Error serialising to JSON: ", e);
+            throw new ServiceException("Error serialising to JSON", e);
+        } catch (IOException e) {
+            //TODO: Use structured Logging 
+            LOG.error("Error serialising to JSON or sending payload: ", e);
+            throw new ServiceException("Error serialising to JSON or sending payload", e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
@@ -34,15 +34,19 @@ public class PscSubmissionSender {
 
     private final String postUrl;
     
+    private ObjectMapper objectMapper;
+
     public PscSubmissionSender() {
         this(new EnvironmentReaderImpl());
     }
-    
+
     public PscSubmissionSender(EnvironmentReader environmentReader) {
         this.postUrl = environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT);
+        this.objectMapper = new ObjectMapper();
     }
 
-    public boolean send(PscSubmission submission,CloseableHttpClient client,ObjectMapper objectMapper,String requestId) throws ServiceException {
+    public boolean send(PscSubmission submission, CloseableHttpClient client, String requestId)
+            throws ServiceException {
         try {
             submission.setRequestId(requestId);
             String discrepancyJson = objectMapper.writeValueAsString(submission);

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
 import uk.gov.companieshouse.service.ServiceException;
 
 /**
- * Listens for the creation of a PscDiscrepancySurvey, converts it to JSON, and sends by HTTP POST
+ * Listens for a completed PscDiscrepancyReport, converts it to JSON, and sends by HTTP POST
  * it to the supplied URL.
  *
  */

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscDiscrepancy.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscDiscrepancy.java
@@ -42,4 +42,9 @@ public class PscDiscrepancy extends ApiObjectImpl {
             && Objects.deepEquals(super.getLinks(), other.getLinks())
             && Objects.equals(details, other.details);
     }
+
+    @Override
+    public String toString() {
+        return "PscDiscrepancy [details=" + details + "]";
+    }
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscSubmission.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscSubmission.java
@@ -1,0 +1,72 @@
+package uk.gov.ch.pscdiscrepanciesapi.models.rest;
+
+import java.util.List;
+
+public class PscSubmission {
+    
+    private String requestId;
+    private PscDiscrepancyReport report;
+    private List<PscDiscrepancy> discrepancies;
+
+    public PscDiscrepancyReport getReport() {
+        return report;
+    }
+
+    public void setReport(PscDiscrepancyReport report) {
+        this.report = report;
+    }
+
+    public List<PscDiscrepancy> getDiscrepancies() {
+        return discrepancies;
+    }
+
+    public void setDiscrepancies(List<PscDiscrepancy> discrepancies) {
+        this.discrepancies = discrepancies;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((discrepancies == null) ? 0 : discrepancies.hashCode());
+        result = prime * result + ((report == null) ? 0 : report.hashCode());
+        result = prime * result + ((requestId == null) ? 0 : requestId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PscSubmission other = (PscSubmission) obj;
+        if (discrepancies == null) {
+            if (other.discrepancies != null)
+                return false;
+        } else if (!discrepancies.equals(other.discrepancies))
+            return false;
+        if (report == null) {
+            if (other.report != null)
+                return false;
+        } else if (!report.equals(other.report))
+            return false;
+        if (requestId == null) {
+            if (other.requestId != null)
+                return false;
+        } else if (!requestId.equals(other.requestId))
+            return false;
+        return true;
+    }
+    
+}

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscSubmission.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscSubmission.java
@@ -1,6 +1,7 @@
 package uk.gov.ch.pscdiscrepanciesapi.models.rest;
 
 import java.util.List;
+import java.util.Objects;
 
 public class PscSubmission {
     
@@ -51,11 +52,7 @@ public class PscSubmission {
         if (getClass() != obj.getClass())
             return false;
         PscSubmission other = (PscSubmission) obj;
-        if (discrepancies == null) {
-            if (other.discrepancies != null)
-                return false;
-        } else if (!discrepancies.equals(other.discrepancies))
-            return false;
+
         if (report == null) {
             if (other.report != null)
                 return false;
@@ -66,7 +63,12 @@ public class PscSubmission {
                 return false;
         } else if (!requestId.equals(other.requestId))
             return false;
-        return true;
+        return Objects.deepEquals(discrepancies, other.discrepancies);
     }
-    
+
+    @Override
+    public String toString() {
+        return "PscSubmission [requestId=" + requestId + ", report=" + report + ", discrepancies="
+                        + discrepancies + "]";
+    }
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/ReportStatus.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/ReportStatus.java
@@ -5,5 +5,6 @@ public enum ReportStatus {
     COMPLETE,
     INVALID,
     SUBMITTED,
-    DELETED;
+    DELETED,
+    FAILED_TO_SUBMIT;
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -327,9 +327,6 @@ public class PscDiscrepancyReportService {
             reportToSubmit.setDiscrepancies(reportDetails.getData());
             reportSent = pscSubmissionSender.send(reportToSubmit, httpClient, new ObjectMapper(),
                             request.getSession().getId());
-        } catch (MongoException mongoEx) {
-            LOG.error("Error saving report with new status after attempting to submit report, with reportSent: "
-                            + reportSent, mongoEx);
         } catch (ServiceException ex) {
             LOG.error("ERROR Sending JSON to CHIPS Rest Interfaces ", ex);
         } catch (IOException e) {

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -109,9 +109,7 @@ public class PscDiscrepancyReportService {
         Errors validationErrors = validateCreate(pscDiscrepancyReport);
 
         if (validationErrors.hasErrors()) {
-            Map<String, Object> debugMap = new HashMap<>();
-            debugMap.put("validationErrors", validationErrors);
-            LOG.error("Validation errors", debugMap);
+            LOG.error("Validation errors", buildErrorLogMap(validationErrors));
             return ServiceResult.invalid(validationErrors);
         }
 

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
@@ -1,0 +1,143 @@
+package uk.gov.ch.pscdiscrepanciesapi.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscSubmission;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.service.ServiceException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class PscSubmissionSenderTest {
+
+    @Mock
+    private CloseableHttpResponse response;
+    @Mock
+    private HttpEntity entity;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private StatusLine statusLine;
+    @Mock
+    private CloseableHttpClient client;
+    @Mock
+    private EnvironmentReader environmentReader;
+
+    private PscSubmissionSender submissionSender;
+    @Captor
+    private ArgumentCaptor<HttpPost> argCaptor;
+    private static final String REQUEST_ID = "1234";
+    private static final String REST_API = "http://test.ch:00000/chips";
+    private static final String CHIPS_REST_INTERFACE_ENDPOINT = "CHIPS_REST_INTERFACE_ENDPOINT";
+    private PscSubmission submission;
+
+    @BeforeEach
+    public void setUp() {
+        when(environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT)).thenReturn(REST_API);
+        submissionSender = new PscSubmissionSender(environmentReader);
+        submission = new PscSubmission();
+    }
+
+    @Test
+    public void testJsonSentSuccessfully() throws ClientProtocolException, IOException, ServiceException {
+        when(objectMapper.writeValueAsString(submission)).thenReturn("\"jsonSuccessful\"");
+        when(client.execute(any(HttpPost.class))).thenReturn(response);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_ACCEPTED);
+        submissionSender.send(submission, client, objectMapper, REQUEST_ID);
+        // assertTrue(submissionSender.send(submission, client, objectMapper, null));
+
+        verify(client).execute(argCaptor.capture());
+
+        HttpPost httpPost = argCaptor.getValue();
+        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
+        String result = IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
+        assertEquals("\"jsonSuccessful\"", result);
+
+    }
+
+    @Test
+    public void testJsonSentUnsuccessfully() throws ClientProtocolException, IOException, ServiceException {
+        when(objectMapper.writeValueAsString(submission)).thenReturn("\"jsonUnsuccessful\"");
+        when(client.execute(any(HttpPost.class))).thenReturn(response);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_BAD_GATEWAY);
+        submissionSender.send(submission, client, objectMapper, REQUEST_ID);
+
+        verify(client).execute(argCaptor.capture());
+
+        HttpPost httpPost = argCaptor.getValue();
+        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
+        String result = IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
+        assertEquals("\"jsonUnsuccessful\"", result);
+    }
+
+    @Test
+    public void testThrowsJsonProcessingException() throws ClientProtocolException, IOException, ServiceException {
+        when(objectMapper.writeValueAsString(submission)).thenThrow(new JsonProcessingException("") {
+            private static final long serialVersionUID = 1L;
+        });
+        ServiceException se = assertThrows(ServiceException.class,
+                () -> submissionSender.send(submission, client, objectMapper, REQUEST_ID));
+
+        String exceptionMessage = se.getMessage();
+        assertTrue(exceptionMessage.contains("Error serialising to JSON"));
+    }
+
+    @Test
+    void whenBadJsonSuppliedThenItIsSanitisedBeforeSending()
+            throws ClientProtocolException, IOException, ServiceException {
+        when(objectMapper.writeValueAsString(submission)).thenReturn("unquotedString");
+        when(client.execute(any(HttpPost.class))).thenReturn(response);
+        when(response.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_ACCEPTED);
+        submissionSender.send(submission, client, objectMapper, REQUEST_ID);
+
+        verify(client).execute((HttpUriRequest) argCaptor.capture());
+
+        HttpPost httpPost = (HttpPost) argCaptor.getValue();
+        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
+        String result = IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
+        assertEquals("\"unquotedString\"", result);
+    }
+
+    @Test
+    public void testThrowsIOException() throws ClientProtocolException, IOException, ServiceException {
+        when(objectMapper.writeValueAsString(submission)).thenReturn("");
+        when(client.execute(any(HttpPost.class))).thenThrow(new IOException());
+
+        ServiceException se = assertThrows(ServiceException.class,
+                () -> submissionSender.send(submission, client, objectMapper, REQUEST_ID));
+
+        String exceptionMessage = se.getMessage();
+        assertTrue(exceptionMessage.contains("Error serialising to JSON or sending payload"));
+    }
+}

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
@@ -1,13 +1,17 @@
 package uk.gov.ch.pscdiscrepanciesapi.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
@@ -16,7 +20,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,9 +31,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancy;
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancyReport;
 import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscSubmission;
+import uk.gov.ch.pscdiscrepanciesapi.models.rest.ReportStatus;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.service.ServiceException;
 
@@ -40,15 +48,15 @@ public class PscSubmissionSenderTest {
     private static final String REQUEST_ID = "1234";
     private static final String REST_API = "http://test.ch:00000/chips";
     private static final String CHIPS_REST_INTERFACE_ENDPOINT = "CHIPS_REST_INTERFACE_ENDPOINT";
+    private static final String DISCREPANCY_DETAILS = "discrepancy";
+    private static final String VALID_EMAIL = "m@m.com";
+    private static final String ETAG_1 = "1";
 
     @Mock
     private CloseableHttpResponse response;
 
     @Mock
     private HttpEntity entity;
-
-    @Mock
-    private ObjectMapper objectMapper;
 
     @Mock
     private StatusLine statusLine;
@@ -70,70 +78,52 @@ public class PscSubmissionSenderTest {
         when(environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT)).thenReturn(REST_API);
         submissionSender = new PscSubmissionSender(environmentReader);
         submission = new PscSubmission();
+        PscDiscrepancyReport report = createReport(VALID_EMAIL, ReportStatus.COMPLETE.toString());
+        List<PscDiscrepancy> discrepancies = createDiscrepancies(DISCREPANCY_DETAILS);
+        submission.setReport(report);
+        submission.setDiscrepancies(discrepancies);
     }
-
+    
+    private String getCapturedPostBody() throws IOException {
+        HttpPost httpPost = capturedPost.getValue();
+        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
+        return IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
+    }
+    
+    private String toJson(PscSubmission pscSubmission) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(pscSubmission);
+    }
     @Test
     public void testJsonSentSuccessfully() throws ClientProtocolException, IOException, ServiceException {
-        when(objectMapper.writeValueAsString(submission)).thenReturn("\"jsonSuccessful\"");
+        
         when(client.execute(any(HttpPost.class))).thenReturn(response);
         when(response.getStatusLine()).thenReturn(statusLine);
         when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_ACCEPTED);
         assertTrue(submissionSender.send(submission, client, REQUEST_ID));
-
+        
         verify(client).execute(capturedPost.capture());
-
-        HttpPost httpPost = capturedPost.getValue();
-        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
-        String result = IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
-        assertEquals("\"jsonSuccessful\"", result);
+        String capturedPostBody = getCapturedPostBody();
+        String expectedPostBody = toJson(submission);
+        assertEquals(expectedPostBody, capturedPostBody);
     }
 
     @Test
     public void testJsonSentUnsuccessfully() throws ClientProtocolException, IOException, ServiceException {
-        when(objectMapper.writeValueAsString(submission)).thenReturn("\"jsonUnsuccessful\"");
         when(client.execute(any(HttpPost.class))).thenReturn(response);
         when(response.getStatusLine()).thenReturn(statusLine);
         when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_BAD_GATEWAY);
-        submissionSender.send(submission, client, REQUEST_ID);
+        assertFalse(submissionSender.send(submission, client, REQUEST_ID));
 
         verify(client).execute(capturedPost.capture());
 
-        HttpPost httpPost = capturedPost.getValue();
-        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
-        String result = IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
-        assertEquals("\"jsonUnsuccessful\"", result);
-    }
-
-    @Test
-    public void testThrowsJsonProcessingException() throws ClientProtocolException, IOException, ServiceException {
-        when(objectMapper.writeValueAsString(submission)).thenThrow(JsonProcessingException.class);
-        ServiceException se = assertThrows(ServiceException.class,
-                () -> submissionSender.send(submission, client, REQUEST_ID));
-
-        String exceptionMessage = se.getMessage();
-        assertTrue(exceptionMessage.contains("Error serialising to JSON"));
-    }
-
-    @Test
-    void whenBadJsonSuppliedThenItIsSanitisedBeforeSending()
-            throws ClientProtocolException, IOException, ServiceException {
-        when(objectMapper.writeValueAsString(submission)).thenReturn("unquotedString");
-        when(client.execute(any(HttpPost.class))).thenReturn(response);
-        when(response.getStatusLine()).thenReturn(statusLine);
-        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_ACCEPTED);
-        submissionSender.send(submission, client, REQUEST_ID);
-
-        verify(client).execute((HttpUriRequest) capturedPost.capture());
-
-        HttpPost httpPost = (HttpPost) capturedPost.getValue();
-        StringEntity stringEntity = (StringEntity) httpPost.getEntity();
-        String result = IOUtils.toString(stringEntity.getContent(), StandardCharsets.UTF_8);
-        assertEquals("\"unquotedString\"", result);
+        String capturedPostBody = getCapturedPostBody();
+        String expectedPostBody = toJson(submission);
+        assertEquals(expectedPostBody, capturedPostBody);
     }
 
     @Test
     public void testThrowsIOException() throws ClientProtocolException, IOException, ServiceException {
-        when(objectMapper.writeValueAsString(submission)).thenReturn("");
         when(client.execute(any(HttpPost.class))).thenThrow(new IOException());
 
         ServiceException se = assertThrows(ServiceException.class,
@@ -142,4 +132,24 @@ public class PscSubmissionSenderTest {
         String exceptionMessage = se.getMessage();
         assertTrue(exceptionMessage.contains("Error serialising to JSON or sending payload"));
     }
+    
+    private List<PscDiscrepancy> createDiscrepancies(String... discrepancies) {
+        List<PscDiscrepancy> pscDiscrepancies = new ArrayList<>();
+        for (String discrepancy : discrepancies) {
+            PscDiscrepancy pscDiscrepancy = new PscDiscrepancy();
+            pscDiscrepancy.setDetails(discrepancy);
+            pscDiscrepancies.add(pscDiscrepancy);
+        }
+        return pscDiscrepancies;
+    }
+
+    private PscDiscrepancyReport createReport(String obligedEntityEmail, String status) {
+        PscDiscrepancyReport report = new PscDiscrepancyReport();
+        report.setObligedEntityEmail(obligedEntityEmail);
+        report.setStatus(status);
+        report.setEtag(ETAG_1);
+        return report;
+    }
+    
+    
 }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
@@ -102,9 +102,7 @@ public class PscSubmissionSenderTest {
 
     @Test
     public void testThrowsJsonProcessingException() throws ClientProtocolException, IOException, ServiceException {
-        when(objectMapper.writeValueAsString(submission)).thenThrow(new JsonProcessingException("") {
-            private static final long serialVersionUID = 1L;
-        });
+        when(objectMapper.writeValueAsString(submission)).thenThrow(JsonProcessingException.class);
         ServiceException se = assertThrows(ServiceException.class,
                 () -> submissionSender.send(submission, client, objectMapper, REQUEST_ID));
 

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
@@ -78,7 +78,7 @@ public class PscSubmissionSenderTest {
         when(client.execute(any(HttpPost.class))).thenReturn(response);
         when(response.getStatusLine()).thenReturn(statusLine);
         when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_ACCEPTED);
-        assertTrue(submissionSender.send(submission, client, objectMapper, REQUEST_ID));
+        assertTrue(submissionSender.send(submission, client, REQUEST_ID));
 
         verify(client).execute(capturedPost.capture());
 
@@ -94,7 +94,7 @@ public class PscSubmissionSenderTest {
         when(client.execute(any(HttpPost.class))).thenReturn(response);
         when(response.getStatusLine()).thenReturn(statusLine);
         when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_BAD_GATEWAY);
-        submissionSender.send(submission, client, objectMapper, REQUEST_ID);
+        submissionSender.send(submission, client, REQUEST_ID);
 
         verify(client).execute(capturedPost.capture());
 
@@ -108,7 +108,7 @@ public class PscSubmissionSenderTest {
     public void testThrowsJsonProcessingException() throws ClientProtocolException, IOException, ServiceException {
         when(objectMapper.writeValueAsString(submission)).thenThrow(JsonProcessingException.class);
         ServiceException se = assertThrows(ServiceException.class,
-                () -> submissionSender.send(submission, client, objectMapper, REQUEST_ID));
+                () -> submissionSender.send(submission, client, REQUEST_ID));
 
         String exceptionMessage = se.getMessage();
         assertTrue(exceptionMessage.contains("Error serialising to JSON"));
@@ -121,7 +121,7 @@ public class PscSubmissionSenderTest {
         when(client.execute(any(HttpPost.class))).thenReturn(response);
         when(response.getStatusLine()).thenReturn(statusLine);
         when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_ACCEPTED);
-        submissionSender.send(submission, client, objectMapper, REQUEST_ID);
+        submissionSender.send(submission, client, REQUEST_ID);
 
         verify(client).execute((HttpUriRequest) capturedPost.capture());
 
@@ -137,7 +137,7 @@ public class PscSubmissionSenderTest {
         when(client.execute(any(HttpPost.class))).thenThrow(new IOException());
 
         ServiceException se = assertThrows(ServiceException.class,
-                () -> submissionSender.send(submission, client, objectMapper, REQUEST_ID));
+                () -> submissionSender.send(submission, client, REQUEST_ID));
 
         String exceptionMessage = se.getMessage();
         assertTrue(exceptionMessage.contains("Error serialising to JSON or sending payload"));

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.MongoException;
 import uk.gov.ch.pscdiscrepanciesapi.common.LinkFactory;
 import uk.gov.ch.pscdiscrepanciesapi.common.PscSubmissionSender;
@@ -95,13 +94,10 @@ public class PscDiscrepancyReportServiceUnitTest {
     @Test
     @DisplayName("Test findByPscDiscrepancyReportId is successful")
     void verifyFindByIdSuccessful() {
-        when(mockReportRepo.findById(REPORT_ID))
-                .thenReturn(Optional.of(pscDiscrepancyReportEntity));
-        when(mockReportMapper.entityToRest(pscDiscrepancyReportEntity))
-                .thenReturn(pscDiscrepancyReport);
+        when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(pscDiscrepancyReportEntity));
+        when(mockReportMapper.entityToRest(pscDiscrepancyReportEntity)).thenReturn(pscDiscrepancyReport);
 
-        PscDiscrepancyReport result =
-                pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
+        PscDiscrepancyReport result = pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
 
         assertNotNull(result);
         assertEquals(pscDiscrepancyReport, result);
@@ -112,8 +108,7 @@ public class PscDiscrepancyReportServiceUnitTest {
     void verifyFindByIdUnsuccessful() {
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.empty());
 
-        PscDiscrepancyReport result =
-                pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
+        PscDiscrepancyReport result = pscDiscrepancyReportService.findPscDiscrepancyReportById(REPORT_ID);
 
         assertNull(result);
     }
@@ -121,21 +116,21 @@ public class PscDiscrepancyReportServiceUnitTest {
     @Test
     @DisplayName("When createPscDiscrepancyReport is successful, then it returns a created ServiceResult.")
     void createPscDiscrepancyReportSuccessful() throws ServiceException {
-        
+
         pscDiscrepancyReport.setObligedEntityEmail(VALID_EMAIL);
-        
+
         PscDiscrepancyReportEntityData pscDiscrepancyReportData = new PscDiscrepancyReportEntityData();
         pscDiscrepancyReportData.setObligedEntityEmail(VALID_EMAIL);
         pscDiscrepancyReportEntity.setData(pscDiscrepancyReportData);
 
         when(mockLinkFactory.createLinkPscDiscrepancyReport(anyString())).thenReturn(SELF_LINK);
-                
+
         when(mockReportRepo.insert(pscDiscrepancyReportEntity)).thenReturn(pscDiscrepancyReportEntity);
         when(mockReportMapper.restToEntity(pscDiscrepancyReport)).thenReturn(pscDiscrepancyReportEntity);
         when(mockReportMapper.entityToRest(pscDiscrepancyReportEntity)).thenReturn(pscDiscrepancyReport);
 
-        ServiceResult<PscDiscrepancyReport> result =
-                pscDiscrepancyReportService.createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService
+                .createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.CREATED, result.getStatus());
@@ -151,8 +146,8 @@ public class PscDiscrepancyReportServiceUnitTest {
                 .withError(OBLIGED_ENTITY_EMAIL + " must not be empty or null").build();
         errData.addError(error);
 
-        ServiceResult<PscDiscrepancyReport> result =
-                pscDiscrepancyReportService.createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService
+                .createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
@@ -170,8 +165,8 @@ public class PscDiscrepancyReportServiceUnitTest {
                 .withError(OBLIGED_ENTITY_EMAIL + " is not in the correct format").build();
         errData.addError(error);
 
-        ServiceResult<PscDiscrepancyReport> result =
-                pscDiscrepancyReportService.createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService
+                .createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest);
 
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
@@ -181,9 +176,9 @@ public class PscDiscrepancyReportServiceUnitTest {
     @Test
     @DisplayName("When createPscDiscrepancyReport catches a MongoException, then it transforms it to a ServiceException.")
     void createPscDiscrepancyReportThrowsServiceException() {
-        
+
         pscDiscrepancyReport.setObligedEntityEmail(VALID_EMAIL);
-        
+
         PscDiscrepancyReportEntityData pscDiscrepancyReportData = new PscDiscrepancyReportEntityData();
         pscDiscrepancyReportData.setObligedEntityEmail(VALID_EMAIL);
         pscDiscrepancyReportEntity.setData(pscDiscrepancyReportData);
@@ -193,8 +188,8 @@ public class PscDiscrepancyReportServiceUnitTest {
         when(mockReportRepo.insert(pscDiscrepancyReportEntity)).thenThrow(new MongoException(""));
         when(mockReportMapper.restToEntity(pscDiscrepancyReport)).thenReturn(pscDiscrepancyReportEntity);
 
-        assertThrows(ServiceException.class, () -> pscDiscrepancyReportService
-                .createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest));
+        assertThrows(ServiceException.class,
+                () -> pscDiscrepancyReportService.createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest));
     }
 
     @Test
@@ -206,9 +201,9 @@ public class PscDiscrepancyReportServiceUnitTest {
         preexistingReportEntity.setData(preexistingReportEntityData);
         PscDiscrepancyReport preexistingReport = createReport(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
         doReturn(Optional.of(preexistingReportEntity)).when(mockReportRepo).findById(REPORT_ID);
-        
+
         doReturn(preexistingReport).when(mockReportMapper).entityToRest(preexistingReportEntity);
-        
+
         PscDiscrepancyReportEntity savedEntity = mock(PscDiscrepancyReportEntity.class);
         PscDiscrepancyReport savedReport = createReport(VALID_EMAIL, ReportStatus.INVALID.toString());
         doReturn(savedEntity).when(mockReportRepo).save(preexistingReportEntity);
@@ -225,12 +220,12 @@ public class PscDiscrepancyReportServiceUnitTest {
     @DisplayName("When updatePscDiscrepancy is supplied with a badly formatted obliged entity email, then it returns an invalid ServiceResult.")
     void updatePscDiscrepancyReportReturnsInvalidServiceResultWhenIncorrectEmailFormat() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
-        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
+        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
+                ReportStatus.INCOMPLETE.toString());
         preexistingReportEntity.setData(preexistingReportEntityData);
         PscDiscrepancyReport preexistingReport = createReport(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(preexistingReportEntity));
-        when(mockReportMapper.entityToRest(preexistingReportEntity))
-                        .thenReturn(preexistingReport);
+        when(mockReportMapper.entityToRest(preexistingReportEntity)).thenReturn(preexistingReport);
 
         Errors errData = new Errors();
         Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_EMAIL)
@@ -238,8 +233,8 @@ public class PscDiscrepancyReportServiceUnitTest {
         errData.addError(error);
 
         PscDiscrepancyReport reportWithUpdatesToApply = createReport(INVALID_EMAIL, ReportStatus.INVALID.toString());
-        ServiceResult<PscDiscrepancyReport> result =
-                        pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID, reportWithUpdatesToApply, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                reportWithUpdatesToApply, mockRequest);
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
         assertTrue(result.getErrors().containsError(error));
@@ -249,21 +244,20 @@ public class PscDiscrepancyReportServiceUnitTest {
     @DisplayName("When updatePscDiscrepancy is supplied with a null status, then it returns an invalid ServiceResult.")
     void updatePscDiscrepancyReportReturnsInvalidServiceResultWhenNullStatus() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
-        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
+        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
+                ReportStatus.INCOMPLETE.toString());
         preexistingReportEntity.setData(preexistingReportEntityData);
         PscDiscrepancyReport preexistingReport = createReport(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(preexistingReportEntity));
-        when(mockReportMapper.entityToRest(preexistingReportEntity))
-                        .thenReturn(preexistingReport);
+        when(mockReportMapper.entityToRest(preexistingReportEntity)).thenReturn(preexistingReport);
 
         Errors errData = new Errors();
-        Err error = Err.invalidBodyBuilderWithLocation(STATUS)
-                        .withError(STATUS + " must not be empty or null").build();
+        Err error = Err.invalidBodyBuilderWithLocation(STATUS).withError(STATUS + " must not be empty or null").build();
         errData.addError(error);
 
         PscDiscrepancyReport reportWithUpdatesToApply = createReport(VALID_EMAIL, null);
-        ServiceResult<PscDiscrepancyReport> result =
-                        pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID, reportWithUpdatesToApply, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                reportWithUpdatesToApply, mockRequest);
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
         assertTrue(result.getErrors().containsError(error));
@@ -273,21 +267,20 @@ public class PscDiscrepancyReportServiceUnitTest {
     @DisplayName("When updatePscDiscrepancy is supplied with an empty status, then it returns an invalid ServiceResult.")
     void updatePscDiscrepancyReportReturnsInvalidServiceResultWhenEmptyStatus() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
-        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
+        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
+                ReportStatus.INCOMPLETE.toString());
         preexistingReportEntity.setData(preexistingReportEntityData);
         PscDiscrepancyReport preexistingReport = createReport(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(preexistingReportEntity));
-        when(mockReportMapper.entityToRest(preexistingReportEntity))
-                        .thenReturn(preexistingReport);
+        when(mockReportMapper.entityToRest(preexistingReportEntity)).thenReturn(preexistingReport);
 
         Errors errData = new Errors();
-        Err error = Err.invalidBodyBuilderWithLocation(STATUS)
-                        .withError(STATUS + " must not be empty or null").build();
+        Err error = Err.invalidBodyBuilderWithLocation(STATUS).withError(STATUS + " must not be empty or null").build();
         errData.addError(error);
 
         PscDiscrepancyReport reportWithUpdatesToApply = createReport(VALID_EMAIL, "");
-        ServiceResult<PscDiscrepancyReport> result =
-                        pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID, reportWithUpdatesToApply, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                reportWithUpdatesToApply, mockRequest);
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
         assertTrue(result.getErrors().containsError(error));
@@ -297,21 +290,21 @@ public class PscDiscrepancyReportServiceUnitTest {
     @DisplayName("When updatePscDiscrepancy is supplied with an unknown status type, then it returns an invalid ServiceResult.")
     void updatePscDiscrepancyReportReturnsInvalidServiceResultWhenUnknownStatus() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
-        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
+        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
+                ReportStatus.INCOMPLETE.toString());
         preexistingReportEntity.setData(preexistingReportEntityData);
         PscDiscrepancyReport preexistingReport = createReport(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(preexistingReportEntity));
-        when(mockReportMapper.entityToRest(preexistingReportEntity))
-                        .thenReturn(preexistingReport);
+        when(mockReportMapper.entityToRest(preexistingReportEntity)).thenReturn(preexistingReport);
 
         Errors errData = new Errors();
-        Err error = Err.invalidBodyBuilderWithLocation(STATUS)
-                .withError(STATUS + " is not one of the correct values").build();
+        Err error = Err.invalidBodyBuilderWithLocation(STATUS).withError(STATUS + " is not one of the correct values")
+                .build();
         errData.addError(error);
 
         PscDiscrepancyReport reportWithUpdatesToApply = createReport(VALID_EMAIL, "Bad status");
-        ServiceResult<PscDiscrepancyReport> result =
-                        pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID, reportWithUpdatesToApply, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                reportWithUpdatesToApply, mockRequest);
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
         assertTrue(result.getErrors().containsError(error));
@@ -321,17 +314,17 @@ public class PscDiscrepancyReportServiceUnitTest {
     @DisplayName("When updatePscDiscrepancy is supplied with different etag to that of the stored discrepancy, then it returns an invalid ServiceResult.")
     void updatePscDiscrepancyReportReturnsInvalidServiceResultWhenDifferentEtag() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
-        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
+        PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
+                ReportStatus.INCOMPLETE.toString());
         preexistingReportEntity.setData(preexistingReportEntityData);
         PscDiscrepancyReport preexistingReport = createReport(VALID_EMAIL, ReportStatus.INCOMPLETE.toString());
         when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.of(preexistingReportEntity));
-        when(mockReportMapper.entityToRest(preexistingReportEntity))
-                        .thenReturn(preexistingReport);
+        when(mockReportMapper.entityToRest(preexistingReportEntity)).thenReturn(preexistingReport);
 
         PscDiscrepancyReport reportWithUpdatesToApply = createReport(VALID_EMAIL, "Bad status");
         reportWithUpdatesToApply.setEtag("2");
-        ServiceResult<PscDiscrepancyReport> result =
-                        pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID, reportWithUpdatesToApply, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                reportWithUpdatesToApply, mockRequest);
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
     }
@@ -339,10 +332,10 @@ public class PscDiscrepancyReportServiceUnitTest {
     @Test
     @DisplayName("When updateDiscrepancyReport cannot find existing report, then it returns not found")
     void updatePscDiscrepancyReportCannotFindExistingReturnsNotFound() throws ServiceException {
-        when(mockReportRepo.findById(REPORT_ID))
-                        .thenReturn(Optional.empty());
+        when(mockReportRepo.findById(REPORT_ID)).thenReturn(Optional.empty());
         PscDiscrepancyReport reportWithUpdatesToApply = new PscDiscrepancyReport();
-        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID, reportWithUpdatesToApply, mockRequest);
+        ServiceResult<PscDiscrepancyReport> result = pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                reportWithUpdatesToApply, mockRequest);
         assertEquals(ServiceResultStatus.NOT_FOUND, result.getStatus());
     }
 
@@ -350,8 +343,8 @@ public class PscDiscrepancyReportServiceUnitTest {
     @DisplayName("When updatePscDiscrepancyReport catches a MongoException from existing report search, then it transforms it to a ServiceException.")
     void updatePscDiscrepancyReportThrowsServiceException() {
         when(mockReportRepo.findById(REPORT_ID)).thenThrow(MongoException.class);
-        assertThrows(ServiceException.class, () -> pscDiscrepancyReportService
-                .updatePscDiscrepancyReport(REPORT_ID, pscDiscrepancyReport, mockRequest));
+        assertThrows(ServiceException.class, () -> pscDiscrepancyReportService.updatePscDiscrepancyReport(REPORT_ID,
+                pscDiscrepancyReport, mockRequest));
     }
 
     @Test
@@ -371,15 +364,15 @@ public class PscDiscrepancyReportServiceUnitTest {
         doReturn(savedReport).when(mockReportMapper).entityToRest(mockSavedEntity);
 
         List<PscDiscrepancy> savedDiscrepancies = createDiscrepancies(DISCREPANCY_DETAILS);
-        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID, mockRequest);
+        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID,
+                mockRequest);
 
         PscSubmission expectedSubmission = new PscSubmission();
         expectedSubmission.setReport(savedReport);
         expectedSubmission.setDiscrepancies(savedDiscrepancies);
 
         setupMockRequestWithMockSession();
-        doReturn(true).when(mockSender).send(eq(expectedSubmission), any(CloseableHttpClient.class),
-                any(ObjectMapper.class), eq(REQUEST_ID));
+        doReturn(true).when(mockSender).send(eq(expectedSubmission), any(CloseableHttpClient.class), eq(REQUEST_ID));
 
         PscDiscrepancyReportEntityData mockSavedEntityData = mock(PscDiscrepancyReportEntityData.class);
         when(mockSavedEntity.getData()).thenReturn(mockSavedEntityData);
@@ -413,15 +406,15 @@ public class PscDiscrepancyReportServiceUnitTest {
         doReturn(savedReport).when(mockReportMapper).entityToRest(mockSavedEntity);
 
         List<PscDiscrepancy> savedDiscrepancies = createDiscrepancies(DISCREPANCY_DETAILS);
-        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID, mockRequest);
+        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID,
+                mockRequest);
 
         PscSubmission expectedSubmission = new PscSubmission();
         expectedSubmission.setReport(savedReport);
         expectedSubmission.setDiscrepancies(savedDiscrepancies);
 
         setupMockRequestWithMockSession();
-        doReturn(false).when(mockSender).send(eq(expectedSubmission), any(CloseableHttpClient.class),
-                any(ObjectMapper.class), eq(REQUEST_ID));
+        doReturn(false).when(mockSender).send(eq(expectedSubmission), any(CloseableHttpClient.class), eq(REQUEST_ID));
 
         PscDiscrepancyReportEntityData mockSavedEntityData = mock(PscDiscrepancyReportEntityData.class);
         when(mockSavedEntity.getData()).thenReturn(mockSavedEntityData);
@@ -455,14 +448,14 @@ public class PscDiscrepancyReportServiceUnitTest {
         doReturn(savedReport).when(mockReportMapper).entityToRest(mockSavedEntity);
 
         List<PscDiscrepancy> savedDiscrepancies = createDiscrepancies(DISCREPANCY_DETAILS);
-        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID, mockRequest);
+        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID,
+                mockRequest);
 
         PscSubmission expectedSubmission = new PscSubmission();
         expectedSubmission.setReport(savedReport);
         expectedSubmission.setDiscrepancies(savedDiscrepancies);
         setupMockRequestWithMockSession();
-        when(mockSender.send(eq(expectedSubmission), any(CloseableHttpClient.class),
-                any(ObjectMapper.class), eq(REQUEST_ID))).thenReturn(true);
+        when(mockSender.send(eq(expectedSubmission), any(CloseableHttpClient.class), eq(REQUEST_ID))).thenReturn(true);
 
         PscDiscrepancyReportEntityData mockSavedEntityData = mock(PscDiscrepancyReportEntityData.class);
 
@@ -497,15 +490,16 @@ public class PscDiscrepancyReportServiceUnitTest {
         doReturn(savedReport).when(mockReportMapper).entityToRest(mockSavedEntity);
 
         List<PscDiscrepancy> savedDiscrepancies = createDiscrepancies(DISCREPANCY_DETAILS);
-        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID, mockRequest);
+        doReturn(ServiceResult.found(savedDiscrepancies)).when(mockDiscrepancyService).getDiscrepancies(REPORT_ID,
+                mockRequest);
 
         PscSubmission expectedSubmission = new PscSubmission();
         expectedSubmission.setReport(savedReport);
         expectedSubmission.setDiscrepancies(savedDiscrepancies);
 
         setupMockRequestWithMockSession();
-        when(mockSender.send(eq(expectedSubmission), any(CloseableHttpClient.class),
-                any(ObjectMapper.class), eq(REQUEST_ID))).thenThrow(ServiceException.class);
+        when(mockSender.send(eq(expectedSubmission), any(CloseableHttpClient.class), eq(REQUEST_ID)))
+                .thenThrow(ServiceException.class);
 
         PscDiscrepancyReportEntityData mockSavedEntityData = mock(PscDiscrepancyReportEntityData.class);
         when(mockSavedEntity.getData()).thenReturn(mockSavedEntityData);
@@ -531,6 +525,7 @@ public class PscDiscrepancyReportServiceUnitTest {
         }
         return pscDiscrepancies;
     }
+
     private PscDiscrepancyReport createReport(String obligedEntityEmail, String status) {
         PscDiscrepancyReport report = new PscDiscrepancyReport();
         report.setObligedEntityEmail(obligedEntityEmail);

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
@@ -196,9 +196,7 @@ public class PscDiscrepancyReportServiceUnitTest {
         assertThrows(ServiceException.class, () -> pscDiscrepancyReportService
                 .createPscDiscrepancyReport(pscDiscrepancyReport, mockRequest));
     }
-//TODO Step 1: Get status to not be complete to miss new code, 
-    // step 2: Add new test to test complete status path 
-    //
+
     @Test
     @DisplayName("When updateDiscrepancyReport finds an existing report to update, then it updates it and returns success")
     void updatePscDiscrepancyReport() throws ServiceException {
@@ -337,6 +335,7 @@ public class PscDiscrepancyReportServiceUnitTest {
         assertNotNull(result);
         assertEquals(ServiceResultStatus.VALIDATION_ERROR, result.getStatus());
     }
+
     @Test
     @DisplayName("When updateDiscrepancyReport cannot find existing report, then it returns not found")
     void updatePscDiscrepancyReportCannotFindExistingReturnsNotFound() throws ServiceException {
@@ -356,7 +355,7 @@ public class PscDiscrepancyReportServiceUnitTest {
     }
 
     @Test
-    @DisplayName("When updatePscDiscrepancyReport has an updated report with the status of complete, then it sends the report. If true, save report with status of SUBMITTED")
+    @DisplayName("When a completed report is submitted to updatePscDiscrepancyReport, and the submit to chips succeeds, then the report is saved with a status of SUBMITTED")
     void updatePscDiscrepancyReportSendReportSubmitted() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
         PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
@@ -440,7 +439,7 @@ public class PscDiscrepancyReportServiceUnitTest {
     }
 
     @Test
-    @DisplayName("When updatePscDiscrepancyReport has an updated report with the status of complete, then it sends the report. If true, save report with status of SUBMITTED")
+    @DisplayName("When update leads to a report being sent to chips and the saving of the result of that sent throws a MongoEx, then that ex is swallowed.")
     void updatePscDiscrepancyReportSendReportCatchesMongoEx() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
         PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,
@@ -482,7 +481,7 @@ public class PscDiscrepancyReportServiceUnitTest {
     }
 
     @Test
-    @DisplayName("When updatePscDiscrepancyReport has an updated report with the status of complete, then it sends the report. If true, save report with status of SUBMITTED")
+    @DisplayName("When update leads to a report being sent to chips and the send throws a ServiceException, then the exception is swallowed and report status is saved as FAILED_TO_SEND.")
     void updatePscDiscrepancyReportSendReportCatchesServiceEx() throws ServiceException {
         PscDiscrepancyReportEntity preexistingReportEntity = new PscDiscrepancyReportEntity();
         PscDiscrepancyReportEntityData preexistingReportEntityData = createReportData(VALID_EMAIL,


### PR DESCRIPTION
When a PSC Discrepancy Report gains a status of COMPLETE, then it should be sent to CHIPS.
This PR contains the code to achieve this.

Swagger updated to hold new statuses FAILED_TO_SUBMIT.

Unit tests have high coverage.
Sonar reports look good.
Tested, but not against a live CHIPS box yet.

Fulfils FAML-384.