### PR TITLE
Update how links are stored in Mongo

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscDiscrepancyLinkKeys.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscDiscrepancyLinkKeys.java
@@ -3,7 +3,7 @@ package uk.gov.ch.pscdiscrepanciesapi.common;
 import uk.gov.companieshouse.service.links.LinkKey;
 
 public enum PscDiscrepancyLinkKeys implements LinkKey {
-    PSC_DISCREPANCY_REPORT("psc-discrepancy-reports");
+    PSC_DISCREPANCY_REPORT("psc-discrepancy-report");
 
     private String key;
 

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyMapper.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyMapper.java
@@ -15,7 +15,7 @@ public interface PscDiscrepancyMapper {
     @Mapping(source = "pscDiscrepancyEntity.data.kind", target = "kind")
     @Mapping(source = "pscDiscrepancyEntity.data.etag", target = "etag")
     @Mapping(source = "pscDiscrepancyEntity.data.details", target = "details")
-    @Mapping(source = "pscDiscrepancyEntity.data.links", target = "links")
+    @Mapping(source = "pscDiscrepancyEntity.data.links", target = "links.links")
 
     PscDiscrepancy entityToRest(PscDiscrepancyEntity pscDiscrepancyEntity);
 

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapper.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapper.java
@@ -11,15 +11,15 @@ import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancyReport;
 @Mapper(componentModel = "spring")
 public interface PscDiscrepancyReportMapper {
 
-    @Mapping(source = "pscDiscrepancyReport.data.kind", target = "kind")
-    @Mapping(source = "pscDiscrepancyReport.data.etag", target = "etag")
-    @Mapping(source = "pscDiscrepancyReport.data.obligedEntityName", target = "obligedEntityName")
-    @Mapping(source = "pscDiscrepancyReport.data.obligedEntityEmail", target = "obligedEntityEmail")
-    @Mapping(source = "pscDiscrepancyReport.data.companyNumber", target = "companyNumber")
-    @Mapping(source = "pscDiscrepancyReport.data.status", target = "status")
-    @Mapping(source = "pscDiscrepancyReport.data.links", target = "links")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.kind", target = "kind")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.etag", target = "etag")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.obligedEntityName", target = "obligedEntityName")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.obligedEntityEmail", target = "obligedEntityEmail")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.companyNumber", target = "companyNumber")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.status", target = "status")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.links", target = "links.links")
 
-    PscDiscrepancyReport entityToRest(PscDiscrepancyReportEntity pscDiscrepancyReport);
+    PscDiscrepancyReport entityToRest(PscDiscrepancyReportEntity pscDiscrepancyReportEntity);
 
     @InheritInverseConfiguration
     PscDiscrepancyReportEntity restToEntity(PscDiscrepancyReport pscDiscrepancyReport);

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/entity/PscDiscrepancyEntityData.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/entity/PscDiscrepancyEntityData.java
@@ -1,8 +1,7 @@
 package uk.gov.ch.pscdiscrepanciesapi.models.entity;
 
+import java.util.Map;
 import org.springframework.data.mongodb.core.mapping.Field;
-
-import uk.gov.companieshouse.service.links.Links;
 
 public class PscDiscrepancyEntityData {
     @Field("kind")
@@ -15,7 +14,7 @@ public class PscDiscrepancyEntityData {
     private String details;
 
     @Field("links")
-    private Links links;
+    private Map<String, String> links;
 
     public String getKind() {
         return kind;
@@ -41,11 +40,11 @@ public class PscDiscrepancyEntityData {
         this.details = details;
     }
 
-    public Links getLinks() {
+    public Map<String, String> getLinks() {
         return links;
     }
 
-    public void setLinks(Links links) {
+    public void setLinks(Map<String, String> links) {
         this.links = links;
     }
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/entity/PscDiscrepancyReportEntityData.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/entity/PscDiscrepancyReportEntityData.java
@@ -1,8 +1,8 @@
 package uk.gov.ch.pscdiscrepanciesapi.models.entity;
 
+import java.util.Map;
 import java.util.Objects;
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.service.links.Links;
 
 public class PscDiscrepancyReportEntityData {
     @Field("kind")
@@ -24,7 +24,7 @@ public class PscDiscrepancyReportEntityData {
     private String status;
 
     @Field("links")
-    private Links links;
+    private Map<String, String> links;
 
     public String getKind() {
         return kind;
@@ -74,11 +74,11 @@ public class PscDiscrepancyReportEntityData {
         this.status = status;
     }
 
-    public Links getLinks() {
+    public Map<String, String> getLinks() {
         return links;
     }
 
-    public void setLinks(Links links) {
+    public void setLinks(Map<String, String> links) {
         this.links = links;
     }
 

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -266,14 +266,14 @@ public class PscDiscrepancyReportService {
         return GenerateEtagUtil.generateEtag();
     }
     
-    private Links linksForCreation(String pscDiscrepancyReportId) {
+    private Map<String, String> linksForCreation(String pscDiscrepancyReportId) {
     
         Links links = new Links();
 
         String selfLink = linkFactory.createLinkPscDiscrepancyReport(pscDiscrepancyReportId);
         links.setLink(CoreLinkKeys.SELF, selfLink);
 
-        return links;
+        return links.getLinks();
     }
     
     /**

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -169,7 +169,7 @@ public class PscDiscrepancyService {
      * 
      * @return a Links object containing links to self and parent
      */
-    private Links linksForCreation(String pscDiscrepancyId, String pscDiscrepancyReportId) {
+    private Map<String, String> linksForCreation(String pscDiscrepancyId, String pscDiscrepancyReportId) {
 
         Links links = new Links();
 
@@ -179,7 +179,7 @@ public class PscDiscrepancyService {
         String pscDiscrepancyReportLink = linkFactory.createLinkPscDiscrepancyReport(pscDiscrepancyReportId);
         links.setLink(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT, pscDiscrepancyReportLink);
 
-        return links;
+        return links.getLinks();
     }
 
     /**

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyMapperUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyMapperUnitTest.java
@@ -1,14 +1,16 @@
 package uk.gov.ch.pscdiscrepanciesapi.mappers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntityData;
 import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntity;
+import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntityData;
 import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancy;
 import uk.gov.companieshouse.service.links.Links;
 
@@ -20,6 +22,7 @@ public class PscDiscrepancyMapperUnitTest {
     private static final String KIND = "kind";
     private static final String ETAG = "etag";
     private static final String DISCREPANCY_DETAILS = "details";
+    private static final Map<String, String> MAP_LINKS = new HashMap<>();
     private static final Links LINKS = new Links();
 
     private PscDiscrepancy pscDiscrepancy;
@@ -35,7 +38,7 @@ public class PscDiscrepancyMapperUnitTest {
         pscDiscrepancyData.setKind(KIND);
         pscDiscrepancyData.setEtag(ETAG);
         pscDiscrepancyData.setDetails(DISCREPANCY_DETAILS);
-        pscDiscrepancyData.setLinks(LINKS);
+        pscDiscrepancyData.setLinks(MAP_LINKS);
         pscDiscrepancyEntity.setData(pscDiscrepancyData);
 
         pscDiscrepancy = new PscDiscrepancy();

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapperUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapperUnitTest.java
@@ -12,6 +12,8 @@ import uk.gov.ch.pscdiscrepanciesapi.models.rest.PscDiscrepancyReport;
 import uk.gov.companieshouse.service.links.Links;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.HashMap;
+import java.util.Map;
 
 @ExtendWith(MockitoExtension.class)
 public class PscDiscrepancyReportMapperUnitTest {
@@ -24,6 +26,7 @@ public class PscDiscrepancyReportMapperUnitTest {
     private static final String OBLIGED_ENTITY_EMAIL = "obligedEntityEmail";
     private static final String COMPANY_NUMBER = "companyNumber";
     private static final Links LINKS = new Links();
+    private static final Map<String, String> MAP_LINKS = new HashMap<>();
 
     private PscDiscrepancyReport pscDiscrepancyReport;
     private PscDiscrepancyReportEntity pscDiscrepancyReportEntity;
@@ -40,7 +43,7 @@ public class PscDiscrepancyReportMapperUnitTest {
         pscDiscrepancyReportData.setObligedEntityName(OBLIGED_ENTITY_NAME);
         pscDiscrepancyReportData.setObligedEntityEmail(OBLIGED_ENTITY_EMAIL);
         pscDiscrepancyReportData.setCompanyNumber(COMPANY_NUMBER);
-        pscDiscrepancyReportData.setLinks(LINKS);
+        pscDiscrepancyReportData.setLinks(MAP_LINKS);
         pscDiscrepancyReportEntity.setData(pscDiscrepancyReportData);
 
         pscDiscrepancyReport = new PscDiscrepancyReport();

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyServiceUnitTest.java
@@ -320,13 +320,13 @@ public class PscDiscrepancyServiceUnitTest {
         return pscDiscrepancyEntity;
     }
 
-    private Links createLinks() {
+    private Map<String, String> createLinks() {
         Links links = new Links();
         Map<String, String> linksMap = new HashMap<String, String>();
         linksMap.put("self", SELF_LINK);
         linksMap.put(PscDiscrepancyLinkKeys.PSC_DISCREPANCY_REPORT.toString(), PARENT_LINK);
         links.setLinks(linksMap);
-        return links;
+        return links.getLinks();
     }
 
     private Err createErrors(String field, String message) {


### PR DESCRIPTION
Update how links are stored in Mongo for a PSC Discrepancy Report and PSC discrepancies.
Changed type for links on PscDiscrepancyReportEntityData and PscDiscrepancyEntityData classes to a Map<String, String>
Updated affected classes
Updated mapper classes PscDiscrepancyReportMapper and PscDiscrepancyMapper to map to the correct field

FAML-410