### PR TITLE
Make config vars in code line up with environments

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
@@ -29,7 +29,7 @@ import uk.gov.companieshouse.service.ServiceException;
 @Service
 public class PscSubmissionSender {
 
-    private static final String CPSC_DISCREPANCY_REPORT_SUBMISSION_URI =
+    private static final String PSC_DISCREPANCY_REPORT_SUBMISSION_URI =
                     "PSC_DISCREPANCY_REPORT_SUBMISSION_URI";
     private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -41,7 +41,7 @@ public class PscSubmissionSender {
     }
 
     public PscSubmissionSender(EnvironmentReader environmentReader) {
-        this.postUrl = environmentReader.getMandatoryString(CPSC_DISCREPANCY_REPORT_SUBMISSION_URI);
+        this.postUrl = environmentReader.getMandatoryString(PSC_DISCREPANCY_REPORT_SUBMISSION_URI);
     }
 
     public boolean send(PscSubmission submission, CloseableHttpClient client, String requestId)

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSender.java
@@ -29,7 +29,8 @@ import uk.gov.companieshouse.service.ServiceException;
 @Service
 public class PscSubmissionSender {
 
-    private static final String CHIPS_REST_INTERFACE_ENDPOINT = "CHIPS_REST_INTERFACE_ENDPOINT";
+    private static final String CPSC_DISCREPANCY_REPORT_SUBMISSION_URI =
+                    "PSC_DISCREPANCY_REPORT_SUBMISSION_URI";
     private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -40,7 +41,7 @@ public class PscSubmissionSender {
     }
 
     public PscSubmissionSender(EnvironmentReader environmentReader) {
-        this.postUrl = environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT);
+        this.postUrl = environmentReader.getMandatoryString(CPSC_DISCREPANCY_REPORT_SUBMISSION_URI);
     }
 
     public boolean send(PscSubmission submission, CloseableHttpClient client, String requestId)

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/common/PscSubmissionSenderTest.java
@@ -47,7 +47,7 @@ import uk.gov.companieshouse.service.ServiceException;
 public class PscSubmissionSenderTest {
     private static final String REQUEST_ID = "1234";
     private static final String REST_API = "http://test.ch:00000/chips";
-    private static final String CHIPS_REST_INTERFACE_ENDPOINT = "CHIPS_REST_INTERFACE_ENDPOINT";
+    private static final String PSC_DISCREPANCY_REPORT_SUBMISSION_URI = "PSC_DISCREPANCY_REPORT_SUBMISSION_URI";
     private static final String DISCREPANCY_DETAILS = "discrepancy";
     private static final String VALID_EMAIL = "m@m.com";
     private static final String ETAG_1 = "1";
@@ -75,7 +75,7 @@ public class PscSubmissionSenderTest {
 
     @BeforeEach
     public void setUp() {
-        when(environmentReader.getMandatoryString(CHIPS_REST_INTERFACE_ENDPOINT)).thenReturn(REST_API);
+        when(environmentReader.getMandatoryString(PSC_DISCREPANCY_REPORT_SUBMISSION_URI)).thenReturn(REST_API);
         submissionSender = new PscSubmissionSender(environmentReader);
         submission = new PscSubmission();
         PscDiscrepancyReport report = createReport(VALID_EMAIL, ReportStatus.COMPLETE.toString());


### PR DESCRIPTION
When config was being set up for the new feature 'send report to CHIPS', the environment variable name changed and the code was not brought into line with this change. This commit fixes that.

PSC_DISCREPANCY_REPORT_SUBMISSION_URI->CHIPS_REST_INTERFACES_URI

Original feature: FAML-384