### PR TITLE
Fix Bug for Discrepancy Query + minor logging

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyRepository.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyRepository.java
@@ -11,6 +11,6 @@ import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntity;
 @Repository
 public interface PscDiscrepancyRepository extends MongoRepository<PscDiscrepancyEntity, String> {
 	
-	@Query(value="{'data.links.linksMap.psc-discrepancy-reports' : ?0}")
+	@Query(value="{'data.links.psc-discrepancy-report' : ?0}")
 	public List<PscDiscrepancyEntity> getDiscrepancies(String reportLink);
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyService.java
@@ -147,6 +147,7 @@ public class PscDiscrepancyService {
                 }
                 return ServiceResult.found(retrievedDiscrepancies);
             } else {
+                LOG.error("discrepancies not found");
                 return ServiceResult.notFound();
             }
         } catch (MongoException me) {


### PR DESCRIPTION
PscDiscrepancyService
Fixed a Bug relating to the getDiscrepancies function
which returned null values and caused submission to fail.
I've corrected the statement and added a minor logging line
inside said function