### PR TITLE
Fix minor issues in new telephone number code

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -171,7 +171,7 @@ public class PscDiscrepancyReportService {
                     preexistingReportEntityData.setStatus(reportWithUpdatesToApply.getStatus());
                     preexistingReportEntityData.setObligedEntityEmail(
                                     reportWithUpdatesToApply.getObligedEntityEmail());
-                    preexistingReport.setObligedEntityTelephoneNumber(
+                    preexistingReportEntityData.setObligedEntityTelephoneNumber(
                             reportWithUpdatesToApply.getObligedEntityTelephoneNumber());
                     preexistingReportEntityData
                                     .setCompanyNumber(reportWithUpdatesToApply.getCompanyNumber());

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidator.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidator.java
@@ -49,8 +49,10 @@ public class PscDiscrepancyReportValidator extends Validators {
         validateEmail(errs, pscDiscrepancyReport.getObligedEntityEmail());
         validateCompanyNumber(errs, pscDiscrepancyReport.getCompanyNumber());
         validateStatus(errs, pscDiscrepancyReport.getStatus());
-        validateNotEmpty(pscDiscrepancyReport.getObligedEntityTelephoneNumber(),
-                OBLIGED_ENTITY_TELEPHONE_NUMBER, errs);
+        if (pscDiscrepancyReport.getObligedEntityTelephoneNumber() != null) {
+            validateNotEmpty(pscDiscrepancyReport.getObligedEntityTelephoneNumber(),
+                            OBLIGED_ENTITY_TELEPHONE_NUMBER, errs);
+        }
         return errs;
     }
 

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
@@ -262,6 +262,18 @@ public class PscDiscrepancyReportValidatorUnitTest {
     }
 
     @Test
+    @DisplayName("Validate the whole PscDiscrepancyReport (without optional OE telephone set) before submission to CHIPS successfully")
+    void validateReport_SuccessfulOptionTelephoneNumberNotSet() {
+        Errors errors = new Errors();
+        pscDiscrepancyReport.setStatus("COMPLETE");
+        pscDiscrepancyReport.setObligedEntityTelephoneNumber(null);
+        Errors errorsFromValidation =
+                pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
+
+        assertFalse(errorsFromValidation.hasErrors());
+    }
+
+    @Test
     @DisplayName("Validate the whole PscDiscrepancyReport before submission to CHIPS - invalid email")
     void validateReport_Unsuccessful_InvalidEmail() {
         Errors errors = new Errors();


### PR DESCRIPTION
PscDiscrepancyReportService
Copied data to preexistingReport rather than
 preexistingReportEntityData. Fixed.

PscDiscrepancyReportValidator
Did not expect telephone number to be null, but it is optional so it may
 be. Fixed validate(...) to allow nullity.

PscDiscrepancyReportValidatorTest
Added a test allowing null telephone number:
 validateReport_SuccessfulOptionTelephoneNumberNotSet()