### PR TITLE
Replace lambda with method reference

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -80,7 +80,7 @@ public class PscDiscrepancyReportService {
         Optional<PscDiscrepancyReportEntity> storedReport = pscDiscrepancyReportRepository.findById(reportId);
 
         return storedReport
-                .map(pscDiscrepancyReportEntity -> pscDiscrepancyReportMapper.entityToRest(pscDiscrepancyReportEntity))
+                .map(pscDiscrepancyReportMapper::entityToRest)
                 .orElse(null);
     }
 


### PR DESCRIPTION
Fix sonar code smell by replacing the lambda with a method reference

FAML-427