### PR TITLE
FAML-372 Store Obliged Entity Type

### DIFF
--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapper.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapper.java
@@ -17,6 +17,7 @@ public interface PscDiscrepancyReportMapper {
     @Mapping(source = "pscDiscrepancyReportEntity.data.obligedEntityContactName", target = "obligedEntityContactName")
     @Mapping(source = "pscDiscrepancyReportEntity.data.obligedEntityEmail", target = "obligedEntityEmail")
     @Mapping(source = "pscDiscrepancyReportEntity.data.obligedEntityTelephoneNumber", target = "obligedEntityTelephoneNumber")
+    @Mapping(source = "pscDiscrepancyReportEntity.data.obligedEntityType", target = "obligedEntityType")
     @Mapping(source = "pscDiscrepancyReportEntity.data.companyNumber", target = "companyNumber")
     @Mapping(source = "pscDiscrepancyReportEntity.data.status", target = "status")
     @Mapping(source = "pscDiscrepancyReportEntity.data.links", target = "links.links")

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/entity/PscDiscrepancyReportEntityData.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/entity/PscDiscrepancyReportEntityData.java
@@ -2,6 +2,7 @@ package uk.gov.ch.pscdiscrepanciesapi.models.entity;
 
 import java.util.Map;
 import java.util.Objects;
+
 import org.springframework.data.mongodb.core.mapping.Field;
 
 public class PscDiscrepancyReportEntityData {
@@ -22,6 +23,9 @@ public class PscDiscrepancyReportEntityData {
 
     @Field("obliged_entity_telephone_number")
     private String obligedEntityTelephoneNumber;
+
+    @Field("obliged_entity_type")
+    private String obligedEntityType;
 
     @Field("company_number")
     private String companyNumber;
@@ -80,6 +84,14 @@ public class PscDiscrepancyReportEntityData {
         this.obligedEntityTelephoneNumber = obligedEntityTelephoneNumber;
     }
 
+    public String getObligedEntityType() {
+        return obligedEntityType;
+    }
+
+    public void setObligedEntityType(String obligedEntityType) {
+        this.obligedEntityType = obligedEntityType;
+    }
+
     public String getCompanyNumber() {
         return companyNumber;
     }
@@ -105,33 +117,36 @@ public class PscDiscrepancyReportEntityData {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(companyNumber, etag, kind, links, obligedEntityEmail, obligedEntityName,
-                        status);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PscDiscrepancyReportEntityData that = (PscDiscrepancyReportEntityData) o;
+        return Objects.equals(kind, that.kind) &&
+                Objects.equals(etag, that.etag) &&
+                Objects.equals(obligedEntityContactName, that.obligedEntityContactName) &&
+                Objects.equals(obligedEntityName, that.obligedEntityName) &&
+                Objects.equals(obligedEntityEmail, that.obligedEntityEmail) &&
+                Objects.equals(obligedEntityTelephoneNumber, that.obligedEntityTelephoneNumber) &&
+                Objects.equals(obligedEntityType, that.obligedEntityType) &&
+                Objects.equals(companyNumber, that.companyNumber) &&
+                Objects.equals(status, that.status) &&
+                Objects.equals(links, that.links);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof PscDiscrepancyReportEntityData)) {
-            return false;
-        }
-        PscDiscrepancyReportEntityData other = (PscDiscrepancyReportEntityData) obj;
-        return Objects.equals(companyNumber, other.companyNumber)
-                        && Objects.equals(etag, other.etag) && Objects.equals(kind, other.kind)
-                        && Objects.equals(links, other.links)
-                        && Objects.equals(obligedEntityEmail, other.obligedEntityEmail)
-                        && Objects.equals(obligedEntityName, other.obligedEntityName)
-                        && Objects.equals(status, other.status);
+    public int hashCode() {
+        return Objects.hash(kind, etag, obligedEntityContactName, obligedEntityName, obligedEntityEmail, obligedEntityTelephoneNumber, obligedEntityType, companyNumber, status, links);
     }
 
     @Override
     public String toString() {
-        return "PscDiscrepancyReportEntityData [kind=" + kind + ", etag=" + etag
-                        + ", obligedEntityName=" + obligedEntityName + ", obligedEntityEmail="
-                        + obligedEntityEmail + ", companyNumber=" + companyNumber + ", status="
-                        + status + ", links=" + links + "]";
+        return "PscDiscrepancyReportEntityData [kind=" + kind
+                + ", etag=" + etag
+                + ", obligedEntityName=" + obligedEntityName
+                + ", obligedEntityEmail=" + obligedEntityEmail
+                + ", companyNumber=" + companyNumber
+                + ", status=" + status
+                + ", links=" + links + "]";
     }
+
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscDiscrepancyReport.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscDiscrepancyReport.java
@@ -1,6 +1,7 @@
 package uk.gov.ch.pscdiscrepanciesapi.models.rest;
 
 import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.companieshouse.service.rest.ApiObjectImpl;
 
@@ -17,6 +18,9 @@ public class PscDiscrepancyReport extends ApiObjectImpl {
 
     @JsonProperty("obliged_entity_telephone_number")
     private String obligedEntityTelephoneNumber;
+
+    @JsonProperty("obliged_entity_type")
+    private String obligedEntityType;
 
     @JsonProperty("company_number")
     private String companyNumber;
@@ -56,6 +60,14 @@ public class PscDiscrepancyReport extends ApiObjectImpl {
         this.obligedEntityTelephoneNumber = obligedEntityTelephoneNumber;
     }
 
+    public String getObligedEntityType() {
+        return obligedEntityType;
+    }
+
+    public void setObligedEntityType(String obligedEntityType) {
+        this.obligedEntityType = obligedEntityType;
+    }
+
     public String getCompanyNumber() {
         return companyNumber;
     }
@@ -72,50 +84,32 @@ public class PscDiscrepancyReport extends ApiObjectImpl {
         this.status = status;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((companyNumber == null) ? 0 : companyNumber.hashCode());
-        result = prime * result
-                + ((obligedEntityEmail == null) ? 0 : obligedEntityEmail.hashCode());
-        result = prime * result + ((obligedEntityName == null) ? 0 : obligedEntityName.hashCode());
-        result = prime * result + ((status == null) ? 0 : status.hashCode());
-        return result;
+        return Objects.hash(super.hashCode(), obligedEntityName, obligedEntityContactName, obligedEntityEmail, obligedEntityTelephoneNumber, obligedEntityType, companyNumber, status);
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof PscDiscrepancyReport)) {
-            return false;
-        }
-        PscDiscrepancyReport other = (PscDiscrepancyReport) obj;
-        
-        return Objects.equals(super.getEtag(), other.getEtag())
-            && Objects.equals(super.getKind(), other.getKind())
-            && Objects.deepEquals(super.getLinks(), other.getLinks())
-            && Objects.equals(companyNumber, other.companyNumber)
-            && Objects.equals(obligedEntityEmail, other.obligedEntityEmail)
-            && Objects.equals(obligedEntityName, other.obligedEntityName)
-            && Objects.equals(status, other.status);
-        }
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        PscDiscrepancyReport that = (PscDiscrepancyReport) o;
+        return Objects.equals(obligedEntityName, that.obligedEntityName) &&
+                Objects.equals(obligedEntityContactName, that.obligedEntityContactName) &&
+                Objects.equals(obligedEntityEmail, that.obligedEntityEmail) &&
+                Objects.equals(obligedEntityTelephoneNumber, that.obligedEntityTelephoneNumber) &&
+                Objects.equals(obligedEntityType, that.obligedEntityType) &&
+                Objects.equals(companyNumber, that.companyNumber) &&
+                Objects.equals(status, that.status);
+    }
 
     @Override
     public String toString() {
         return "PscDiscrepancyReport [obligedEntityName=" + obligedEntityName
-                        + ", obligedEntityEmail=" + obligedEntityEmail + ", companyNumber="
-                        + companyNumber + ", status=" + status + "]";
+                + ", obligedEntityEmail=" + obligedEntityEmail
+                + ", companyNumber=" + companyNumber
+                + ", status=" + status + "]";
     }
+
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscSubmission.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/models/rest/PscSubmission.java
@@ -76,9 +76,7 @@ public class PscSubmission {
     
     /**
      * Create a debug map for structured logging
-     * 
-     * @param pscDiscrepancySubmission
-     * 
+     *
      * @return Debug map
      */
     public Map<String, Object> debugMap() {

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportService.java
@@ -173,6 +173,7 @@ public class PscDiscrepancyReportService {
                                     reportWithUpdatesToApply.getObligedEntityEmail());
                     preexistingReportEntityData.setObligedEntityTelephoneNumber(
                             reportWithUpdatesToApply.getObligedEntityTelephoneNumber());
+                    preexistingReportEntityData.setObligedEntityType(reportWithUpdatesToApply.getObligedEntityType());
                     preexistingReportEntityData
                                     .setCompanyNumber(reportWithUpdatesToApply.getCompanyNumber());
                     preexistingReportEntityData.setObligedEntityContactName(

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidator.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidator.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.service.rest.err.Errors;
 public class PscDiscrepancyReportValidator extends Validators {
     private static final String OBLIGED_ENTITY_EMAIL = "obliged_entity_email";
     private static final String OBLIGED_ENTITY_CONTACT_NAME = "obliged_entity_contact_name";
+    private static final String OBLIGED_ENTITY_TYPE = "obliged_entity_type";
     private static final String COMPANY_INCORPORATION_NUMBER = "company_number";
     private static final String STATUS = "status";
     private static final String ETAG = "etag";
@@ -44,6 +45,7 @@ public class PscDiscrepancyReportValidator extends Validators {
      * @param errs An Err instance is added to this for each validation problem.
      */
     public Errors validate(PscDiscrepancyReport pscDiscrepancyReport, Errors errs) {
+        validateObligedEntityType(errs, pscDiscrepancyReport.getObligedEntityType());
         validateContactName(errs, pscDiscrepancyReport.getObligedEntityContactName());
         validateEmail(errs, pscDiscrepancyReport.getObligedEntityEmail());
         validateCompanyNumber(errs, pscDiscrepancyReport.getCompanyNumber());
@@ -59,7 +61,7 @@ public class PscDiscrepancyReportValidator extends Validators {
      * @param errs An Err instance is added to this for each validation problem.
      */
     public Errors validateForCreation(PscDiscrepancyReport pscDiscrepancyReport, Errors errs) {
-        validateContactName(errs, pscDiscrepancyReport.getObligedEntityContactName());
+        validateObligedEntityType(errs, pscDiscrepancyReport.getObligedEntityType());
         return errs;
     }
     
@@ -127,6 +129,19 @@ public class PscDiscrepancyReportValidator extends Validators {
 
         return errors;
     }
+
+    /**
+     * Validate obliged entity type
+     *
+     * @param obligedEntityType Type to validate
+     *
+     * @return Errors object containing any errors
+     */
+    private Errors validateObligedEntityType(Errors errors, String obligedEntityType) {
+        validateNotBlank(obligedEntityType, OBLIGED_ENTITY_TYPE, errors);
+        return errors;
+    }
+
 
     /**
      * Validate obliged entity email.

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapperUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/mappers/PscDiscrepancyReportMapperUnitTest.java
@@ -26,6 +26,7 @@ public class PscDiscrepancyReportMapperUnitTest {
     private static final String OBLIGED_ENTITY_NAME = "obligedEntityName";
     private static final String OBLIGED_ENTITY_EMAIL = "obligedEntityEmail";
     private static final String OBLIGED_ENTITY_TELEPHONE_NUMBER = "obligedEntityTelephoneNumber";
+    private static final String OBLIGED_ENTITY_TYPE = "obligedEntityType";
     private static final String COMPANY_NUMBER = "companyNumber";
     private static final Links LINKS = new Links();
     private static final Map<String, String> MAP_LINKS = new HashMap<>();
@@ -46,6 +47,7 @@ public class PscDiscrepancyReportMapperUnitTest {
         pscDiscrepancyReportData.setObligedEntityContactName(OBLIGED_ENTTIY_CONTACT_NAME);
         pscDiscrepancyReportData.setObligedEntityEmail(OBLIGED_ENTITY_EMAIL);
         pscDiscrepancyReportData.setObligedEntityTelephoneNumber(OBLIGED_ENTITY_TELEPHONE_NUMBER);
+        pscDiscrepancyReportData.setObligedEntityType(OBLIGED_ENTITY_TYPE);
         pscDiscrepancyReportData.setCompanyNumber(COMPANY_NUMBER);
         pscDiscrepancyReportData.setLinks(MAP_LINKS);
         pscDiscrepancyReportEntity.setData(pscDiscrepancyReportData);
@@ -57,6 +59,7 @@ public class PscDiscrepancyReportMapperUnitTest {
         pscDiscrepancyReport.setObligedEntityContactName(OBLIGED_ENTTIY_CONTACT_NAME);
         pscDiscrepancyReport.setObligedEntityEmail(OBLIGED_ENTITY_EMAIL);
         pscDiscrepancyReport.setObligedEntityTelephoneNumber(OBLIGED_ENTITY_TELEPHONE_NUMBER);
+        pscDiscrepancyReport.setObligedEntityType(OBLIGED_ENTITY_TYPE);
         pscDiscrepancyReport.setCompanyNumber(COMPANY_NUMBER);
         pscDiscrepancyReport.setLinks(LINKS);
     }
@@ -74,6 +77,7 @@ public class PscDiscrepancyReportMapperUnitTest {
         assertEquals(pscDiscrepancyReport.getObligedEntityEmail(), result.getObligedEntityEmail());
         assertEquals(pscDiscrepancyReport.getObligedEntityTelephoneNumber(),
                 result.getObligedEntityTelephoneNumber());
+        assertEquals(pscDiscrepancyReport.getObligedEntityType(), result.getObligedEntityType());
         assertEquals(pscDiscrepancyReport.getCompanyNumber(), result.getCompanyNumber());
         assertEquals(pscDiscrepancyReport.getLinks(), result.getLinks());
     }
@@ -91,6 +95,7 @@ public class PscDiscrepancyReportMapperUnitTest {
         assertEquals(pscDiscrepancyReportEntity.getData().getObligedEntityEmail(), result.getData().getObligedEntityEmail());
         assertEquals(pscDiscrepancyReportEntity.getData().getObligedEntityTelephoneNumber(),
                 result.getData().getObligedEntityTelephoneNumber());
+        assertEquals(pscDiscrepancyReportEntity.getData().getObligedEntityType(), result.getData().getObligedEntityType());
         assertEquals(pscDiscrepancyReportEntity.getData().getCompanyNumber(), result.getData().getCompanyNumber());
         assertEquals(pscDiscrepancyReportEntity.getData().getLinks(), result.getData().getLinks());
     }

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/services/PscDiscrepancyReportServiceUnitTest.java
@@ -60,6 +60,7 @@ public class PscDiscrepancyReportServiceUnitTest {
     private static final String VALID_EMAIL = "m@m.com";
     private static final String INVALID_EMAIL = "mm.com";
     private static final String VALID_TELEPHONE_NUMBER = "08001234567";
+    private static final String VALID_TYPE= "obliged entity type";
     private static final String ETAG_1 = "1";
     private static final String VALID_CONTACT_NAME = "valid-contact-náme";
     private static final String INVALID_CONTACT_NAME = "^invalid-contact-name^";
@@ -235,6 +236,7 @@ public class PscDiscrepancyReportServiceUnitTest {
         PscDiscrepancyReport reportWithUpdatesToApply = createReport(VALID_EMAIL, ReportStatus.INVALID.toString());
         reportWithUpdatesToApply.setObligedEntityContactName(VALID_CONTACT_NAME);
         reportWithUpdatesToApply.setObligedEntityTelephoneNumber(VALID_TELEPHONE_NUMBER);
+        reportWithUpdatesToApply.setObligedEntityType(VALID_TYPE);
 
         when(mockReportDiscrepancyValidator.validateForUpdate(preexistingReport, reportWithUpdatesToApply)).thenReturn(new Errors());
 

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
@@ -35,7 +35,7 @@ public class PscDiscrepancyReportValidatorUnitTest {
 
     private static final String INVALID_CONTACT_NAME = "^InvalidConctactName^";
     private static final String INVALID_COMPANY_NUMBER = "InvalidCompanyNumber";
-    private static final String INVALID_OBLIGED_ENTITY_TYPE = "InvalidObligedEntityType";
+    private static final String INVALID_OBLIGED_ENTITY_TYPE = "";
     private static final String INVALID_STATUS = "NOT_A_VALID_STATUS";
     private static final String INVALID_EMAIL = "Invalid_Email";
 
@@ -240,21 +240,21 @@ public class PscDiscrepancyReportValidatorUnitTest {
         assertFalse(errorsFromValidation.hasErrors());
     }
 
-//    @Test
-//    @DisplayName("Validate the whole PscDiscrepancyReport before submission to CHIPS - invalid obliged entity type")
-//    void validateReport_Unsuccessful_InvalidObligedEntityType() {
-//        Errors errors = new Errors();
-//        pscDiscrepancyReport.setObligedEntityType(INVALID_OBLIGED_ENTITY_TYPE);
-//
-//        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
-//                .withError(OBLIGED_ENTITY_TYPE + " must must not be null").build();
-//
-//        Errors errorsFromValidation =
-//                pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
-//
-//        assertEquals(1, errorsFromValidation.size());
-//        assertTrue(errorsFromValidation.containsError(error));
-//    }
+    @Test
+    @DisplayName("Validate the whole PscDiscrepancyReport before submission to CHIPS - invalid obliged entity type")
+    void validateReport_Unsuccessful_InvalidObligedEntityType() {
+        Errors errors = new Errors();
+        pscDiscrepancyReport.setObligedEntityType(INVALID_OBLIGED_ENTITY_TYPE);
+
+        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
+                .withError(OBLIGED_ENTITY_TYPE + " must not be empty and must not only consist of whitespace").build();
+
+        Errors errorsFromValidation =
+                pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
+
+        assertEquals(1, errorsFromValidation.size());
+        assertTrue(errorsFromValidation.containsError(error));
+    }
 
     @Test
     @DisplayName("Validate the whole PscDiscrepancyReport (without optional OE telephone set) before submission to CHIPS successfully")

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
@@ -240,21 +240,21 @@ public class PscDiscrepancyReportValidatorUnitTest {
         assertFalse(errorsFromValidation.hasErrors());
     }
 
-    @Test
-    @DisplayName("Validate the whole PscDiscrepancyReport before submission to CHIPS - invalid obliged entity type")
-    void validateReport_Unsuccessful_InvalidObligedEntityType() {
-        Errors errors = new Errors();
-        pscDiscrepancyReport.setObligedEntityType(INVALID_OBLIGED_ENTITY_TYPE);
-
-        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
-                .withError(OBLIGED_ENTITY_TYPE + " must must not be null").build();
-
-        Errors errorsFromValidation =
-                pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
-
-        assertEquals(1, errorsFromValidation.size());
-        assertTrue(errorsFromValidation.containsError(error));
-    }
+//    @Test
+//    @DisplayName("Validate the whole PscDiscrepancyReport before submission to CHIPS - invalid obliged entity type")
+//    void validateReport_Unsuccessful_InvalidObligedEntityType() {
+//        Errors errors = new Errors();
+//        pscDiscrepancyReport.setObligedEntityType(INVALID_OBLIGED_ENTITY_TYPE);
+//
+//        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
+//                .withError(OBLIGED_ENTITY_TYPE + " must must not be null").build();
+//
+//        Errors errorsFromValidation =
+//                pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
+//
+//        assertEquals(1, errorsFromValidation.size());
+//        assertTrue(errorsFromValidation.containsError(error));
+//    }
 
     @Test
     @DisplayName("Validate the whole PscDiscrepancyReport (without optional OE telephone set) before submission to CHIPS successfully")

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
@@ -19,12 +19,15 @@ public class PscDiscrepancyReportValidatorUnitTest {
     private static final String OBLIGED_ENTITY_EMAIL_LOCATION = "obliged_entity_email";
     private static final String OBLIGED_ENTITY_TELEPHONE_NUMBER_LOCATION =
             "obliged_entity_telephone_number";
+    private static final String OBLIGED_ENTITY_TYPE = "obliged_entity_type";
     private static final String COMPANY_INCORPORATION_NUMBER_LOCATION = "company_number";
     private static final String STATUS_LOCATION = "status";
 
 
+    private static final String VALID_OBLIGED_ENTITY_TYPE = "valid_oliged_entity_type";
     private static final String VALID_EMAIL = "valid_email@email.com";
     private static final String VALID_TELEPHONE_NUMBER = "08001234567";
+    private static final String VALID_TYPE = "obliged_entity_type";
     private static final String VALID_COMPANY_NUMBER = "12345678";
     private static final String VALID_STATUS = "COMPLETE";
     private static final String VALID_CONTACT_NAME = "ValidContactName";
@@ -32,6 +35,7 @@ public class PscDiscrepancyReportValidatorUnitTest {
 
     private static final String INVALID_CONTACT_NAME = "^InvalidConctactName^";
     private static final String INVALID_COMPANY_NUMBER = "InvalidCompanyNumber";
+    private static final String INVALID_OBLIGED_ENTITY_TYPE = "InvalidObligedEntityType";
     private static final String INVALID_STATUS = "NOT_A_VALID_STATUS";
     private static final String INVALID_EMAIL = "Invalid_Email";
 
@@ -50,6 +54,7 @@ public class PscDiscrepancyReportValidatorUnitTest {
         pscDiscrepancyReport.setObligedEntityContactName(VALID_CONTACT_NAME);
         pscDiscrepancyReport.setObligedEntityEmail(VALID_EMAIL);
         pscDiscrepancyReport.setObligedEntityTelephoneNumber(VALID_TELEPHONE_NUMBER);
+        pscDiscrepancyReport.setObligedEntityType(VALID_TYPE);
         pscDiscrepancyReport.setCompanyNumber(VALID_COMPANY_NUMBER);
         pscDiscrepancyReport.setStatus(VALID_STATUS);
         pscDiscrepancyReport.setEtag(ETAG);
@@ -66,13 +71,13 @@ public class PscDiscrepancyReportValidatorUnitTest {
     }
 
     @Test
-    @DisplayName("Validate unsuccessful creation of a PscDiscrepancyReport - null contactName")
-    void validateCreate_Unsuccessful_NullContactName() {
+    @DisplayName("Validate unsuccessful creation of a PscDiscrepancyReport - null obliged entity type")
+    void validateCreate_Unsuccessful_NullObligedEntityType() {
         Errors errors = new Errors();
-        Err err = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_CONTACT_NAME)
-                .withError(OBLIGED_ENTITY_CONTACT_NAME + NOT_NULL_ERROR_MESSAGE).build();
+        Err err = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
+                .withError(OBLIGED_ENTITY_TYPE + NOT_NULL_ERROR_MESSAGE).build();
 
-        pscDiscrepancyReport.setObligedEntityContactName(null);
+        pscDiscrepancyReport.setObligedEntityType(null);
         Errors errorsFromValidation =
                 pscDiscrepancyReportValidator.validateForCreation(pscDiscrepancyReport, errors);
 
@@ -81,13 +86,13 @@ public class PscDiscrepancyReportValidatorUnitTest {
     }
 
     @Test
-    @DisplayName("Validate unsuccessful creation of a PscDiscrepancyReport - empty contact name")
-    void validateCreate_Unsuccessful_EmptyContactName() {
+    @DisplayName("Validate unsuccessful creation of a PscDiscrepancyReport - empty obliged entity type")
+    void validateCreate_Unsuccessful_EmptyObligedEntityType() {
         Errors errors = new Errors();
-        Err err = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_CONTACT_NAME)
-                .withError(OBLIGED_ENTITY_CONTACT_NAME + NOT_EMPTY_ERROR_MESSAGE).build();
+        Err err = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
+                .withError(OBLIGED_ENTITY_TYPE + NOT_EMPTY_ERROR_MESSAGE).build();
 
-        pscDiscrepancyReport.setObligedEntityContactName("");
+        pscDiscrepancyReport.setObligedEntityType("");
         Errors errorsFromValidation =
                 pscDiscrepancyReportValidator.validateForCreation(pscDiscrepancyReport, errors);
 
@@ -233,6 +238,22 @@ public class PscDiscrepancyReportValidatorUnitTest {
                 pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
 
         assertFalse(errorsFromValidation.hasErrors());
+    }
+
+    @Test
+    @DisplayName("Validate the whole PscDiscrepancyReport before submission to CHIPS - invalid obliged entity type")
+    void validateReport_Unsuccessful_InvalidObligedEntityType() {
+        Errors errors = new Errors();
+        pscDiscrepancyReport.setObligedEntityType(INVALID_OBLIGED_ENTITY_TYPE);
+
+        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_TYPE)
+                .withError(OBLIGED_ENTITY_TYPE + " must must not be null").build();
+
+        Errors errorsFromValidation =
+                pscDiscrepancyReportValidator.validate(pscDiscrepancyReport, errors);
+
+        assertEquals(1, errorsFromValidation.size());
+        assertTrue(errorsFromValidation.containsError(error));
     }
 
     @Test

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/validation/PscDiscrepancyReportValidatorUnitTest.java
@@ -132,8 +132,8 @@ public class PscDiscrepancyReportValidatorUnitTest {
     }
 
     @Test
-    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid email")
-    void validateUpdate_Unsuccessful_InvalidEmail() {
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid email - invalid format")
+    void validateUpdate_Unsuccessful_InvalidEmailInvalidFormat() {
         PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
         updatedReport.setEtag(ETAG);
         updatedReport.setObligedEntityEmail(INVALID_EMAIL);
@@ -149,8 +149,25 @@ public class PscDiscrepancyReportValidatorUnitTest {
     }
 
     @Test
-    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid status")
-    void validateUpdate_Unsuccessful_InvalidStatus() {
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid email - blank")
+    void validateUpdate_Unsuccessful_InvalidEmailBlank() {
+        PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
+        updatedReport.setEtag(ETAG);
+        updatedReport.setObligedEntityEmail("");
+
+        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_EMAIL_LOCATION)
+                .withError(OBLIGED_ENTITY_EMAIL_LOCATION + " must not be empty and must not only consist of whitespace").build();
+
+        Errors errorsFromValidation = pscDiscrepancyReportValidator
+                .validateForUpdate(pscDiscrepancyReport, updatedReport);
+
+        assertEquals(1, errorsFromValidation.size());
+        assertTrue(errorsFromValidation.containsError(error));
+    }
+
+    @Test
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid status - not a valid status")
+    void validateUpdate_Unsuccessful_InvalidStatusNotAValidValue() {
         PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
         updatedReport.setEtag(ETAG);
         updatedReport.setStatus(INVALID_STATUS);
@@ -165,9 +182,27 @@ public class PscDiscrepancyReportValidatorUnitTest {
         assertTrue(errorsFromValidation.containsError(error));
     }
 
+
     @Test
-    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid contact name")
-    void validateUpdate_Unsuccessful_InvalidContactName() {
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid status - blank")
+    void validateUpdate_Unsuccessful_InvalidStatusBlank() {
+        PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
+        updatedReport.setEtag(ETAG);
+        updatedReport.setStatus("");
+
+        Err error = Err.invalidBodyBuilderWithLocation(STATUS_LOCATION)
+                .withError(STATUS_LOCATION + " must not be empty and must not only consist of whitespace").build();
+
+        Errors errorsFromValidation = pscDiscrepancyReportValidator
+                .validateForUpdate(pscDiscrepancyReport, updatedReport);
+
+        assertEquals(1, errorsFromValidation.size());
+        assertTrue(errorsFromValidation.containsError(error));
+    }
+
+    @Test
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid contact name - invalid char")
+    void validateUpdate_Unsuccessful_InvalidContactNameInvalidChar() {
         PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
         updatedReport.setEtag(ETAG);
         updatedReport.setObligedEntityContactName(INVALID_CONTACT_NAME);
@@ -183,14 +218,48 @@ public class PscDiscrepancyReportValidatorUnitTest {
     }
 
     @Test
-    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid company number")
-    void validateUpdate_Unsuccessful_InvalidCompanyNumber() {
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid contact name - blank")
+    void validateUpdate_Unsuccessful_InvalidContactNameBlank() {
+        PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
+        updatedReport.setEtag(ETAG);
+        updatedReport.setObligedEntityContactName("");
+
+        Err error = Err.invalidBodyBuilderWithLocation(OBLIGED_ENTITY_CONTACT_NAME)
+                .withError(OBLIGED_ENTITY_CONTACT_NAME + " must not be empty and must not only consist of whitespace").build();
+
+        Errors errorsFromValidation = pscDiscrepancyReportValidator
+                .validateForUpdate(pscDiscrepancyReport, updatedReport);
+
+        assertEquals(1, errorsFromValidation.size());
+        assertTrue(errorsFromValidation.containsError(error));
+    }
+
+    @Test
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid company number - not 8 chars")
+    void validateUpdate_Unsuccessful_InvalidCompanyNumberNot8Chars() {
         PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
         updatedReport.setEtag(ETAG);
         updatedReport.setCompanyNumber(INVALID_COMPANY_NUMBER);
 
         Err error = Err.invalidBodyBuilderWithLocation(COMPANY_INCORPORATION_NUMBER_LOCATION)
                 .withError(COMPANY_INCORPORATION_NUMBER_LOCATION + " must be 8 characters").build();
+
+        Errors errorsFromValidation = pscDiscrepancyReportValidator
+                .validateForUpdate(pscDiscrepancyReport, updatedReport);
+
+        assertEquals(1, errorsFromValidation.size());
+        assertTrue(errorsFromValidation.containsError(error));
+    }
+
+    @Test
+    @DisplayName("Validate unsuccessful update of a PscDiscrepancyReport - invalid company number - blank")
+    void validateUpdate_Unsuccessful_InvalidCompanyNumberBlank() {
+        PscDiscrepancyReport updatedReport = new PscDiscrepancyReport();
+        updatedReport.setEtag(ETAG);
+        updatedReport.setCompanyNumber("");
+
+        Err error = Err.invalidBodyBuilderWithLocation(COMPANY_INCORPORATION_NUMBER_LOCATION)
+                .withError(COMPANY_INCORPORATION_NUMBER_LOCATION + " must not be empty and must not only consist of whitespace").build();
 
         Errors errorsFromValidation = pscDiscrepancyReportValidator
                 .validateForUpdate(pscDiscrepancyReport, updatedReport);


### PR DESCRIPTION
FAML-372 Store Obliged Entity Type - added functionality to receive, validate, store and retrieve an obliged entity type

Note:
the current toString methods write a subset of the data, this maybe by design so have not added the oe type to these methods