### PR TITLE
corrected swagger to remove hyphens from schema fields.

### DIFF
--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -503,27 +503,27 @@
       "DiscrepancyReport" : {
         "type" : "object",
         "properties" : {
-          "obliged-entity-type" : {
+          "obliged_entity_type" : {
             "type" : "string",
             "example" : "Financial institution"
           },
-          "obliged-entity-name" : {
+          "obliged_entity_organisation_name" : {
             "type" : "string",
             "example" : "Barclays Bank"
           },
-          "obliged-entity-contact-name" : {
+          "obliged_entity_contact_name" : {
             "type" : "string",
             "example" : "Joe Bloggs"
           },
-          "obliged-entity-email" : {
+          "obliged_entity_email" : {
             "type" : "string",
             "example" : "bob.holness@barclaysbank.com"
           },
-          "obliged-entity-telephone-number" : {
+          "obliged_entity_telephone_number" : {
             "type" : "string",
             "example" : "01234 567891"
           },
-          "company-number" : {
+          "company_number" : {
             "type" : "string",
             "example" : "02345678"
           },
@@ -552,7 +552,7 @@
       },
       "Discrepancy" : {
         "properties" : {
-          "discrepancy-reason" : {
+          "discrepancy_reason" : {
             "type" : "string",
             "example" : "Name is incorrect"
           },
@@ -562,7 +562,7 @@
               "self" : {
                 "type" : "string"
               },
-              "report" : {
+              "psc_discrepancy_report" : {
                 "type" : "string"
               }
             }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscDiscrepancyLinkKeys.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscDiscrepancyLinkKeys.java
@@ -3,11 +3,11 @@ package uk.gov.ch.pscdiscrepanciesapi.common;
 import uk.gov.companieshouse.service.links.LinkKey;
 
 public enum PscDiscrepancyLinkKeys implements LinkKey {
-    PSC_DISCREPANCY_REPORT("psc-discrepancy-report");
+    PSC_DISCREPANCY_REPORT("psc_discrepancy_report");
 
     private String key;
 
-    private PscDiscrepancyLinkKeys(String key) {
+    PscDiscrepancyLinkKeys(String key) {
         this.key = key;
     }
 


### PR DESCRIPTION
corrected PSC Discrepancy Report Link key to remove hyphens.
removed redundant private enum constructor.

https://companieshouse.atlassian.net/browse/FAML-751