### PR TITLE
Feature/faml 751 correct hyphens component fields

### DIFF
--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -552,9 +552,17 @@
       },
       "Discrepancy" : {
         "properties" : {
-          "discrepancy_reason" : {
+          "details" : {
             "type" : "string",
             "example" : "Name is incorrect"
+          },
+          "psc_name" : {
+            "type" : "string",
+            "example" : "Mrs Random Random"
+          },
+          "psc_date_of_birth" : {
+            "type" : "string",
+            "example" : "DD/MM/YYY"
           },
           "links" : {
             "type" : "object",

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscDiscrepancyLinkKeys.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/common/PscDiscrepancyLinkKeys.java
@@ -3,7 +3,12 @@ package uk.gov.ch.pscdiscrepanciesapi.common;
 import uk.gov.companieshouse.service.links.LinkKey;
 
 public enum PscDiscrepancyLinkKeys implements LinkKey {
-    PSC_DISCREPANCY_REPORT("psc_discrepancy_report");
+    // Code analysis wants to use the constant value here
+    //however that would be an illegal forward reference, and I cannot use the enum
+    //as annotations need constants. Therefore both are needed and neither can be removed.
+
+    PSC_DISCREPANCY_REPORT("psc_discrepancy_report");//NOSONAR
+    public static final String REPORT_LINK = "psc_discrepancy_report";
 
     private String key;
 

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyRepository.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/repositories/PscDiscrepancyRepository.java
@@ -1,16 +1,15 @@
 package uk.gov.ch.pscdiscrepanciesapi.repositories;
 
 import java.util.List;
-
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
-
+import uk.gov.ch.pscdiscrepanciesapi.common.PscDiscrepancyLinkKeys;
 import uk.gov.ch.pscdiscrepanciesapi.models.entity.PscDiscrepancyEntity;
 
 @Repository
 public interface PscDiscrepancyRepository extends MongoRepository<PscDiscrepancyEntity, String> {
 	
-	@Query(value="{'data.links.psc-discrepancy-report' : ?0}")
-	public List<PscDiscrepancyEntity> getDiscrepancies(String reportLink);
+	@Query(value="{'data.links."+ PscDiscrepancyLinkKeys.REPORT_LINK+"' : ?0}")
+	List<PscDiscrepancyEntity> getDiscrepancies(String reportLink);
 }


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/FAML-751

Manually defined mongo query needed correction.

Also somehow I didn't notice the swagger PSC Discrepancies schema is missing fields.