### PR TITLE
faml-635 add authentication to psc-discrepancies api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,8 +139,6 @@
             <artifactId>api-security-java</artifactId>
             <version>0.3.5</version>
         </dependency>
-
-
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>api-security-java</artifactId>
+            <version>0.3.5</version>
+        </dependency>
 
 
     </dependencies>

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
@@ -18,6 +18,5 @@ public class InterceptorConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry){
         registry.addInterceptor(crudAuthenticationInterceptor());
-
     }
 }

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
@@ -1,0 +1,37 @@
+package uk.gov.ch.pscdiscrepanciesapi.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.ch.pscdiscrepanciesapi.PscDiscrepancyApiApplication;
+import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
+
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import java.beans.PersistenceDelegate;
+
+import static uk.gov.companieshouse.api.util.security.Permission.Key.USER_PSC_DISCREPANCY_REPORT;
+
+
+@Configuration
+public class InterceptorConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
+
+    @Bean
+    public CRUDAuthenticationInterceptor crudAuthenticationInterceptor(){
+        return new CRUDAuthenticationInterceptor(USER_PSC_DISCREPANCY_REPORT);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(crudAuthenticationInterceptor());
+
+    }
+}

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
@@ -8,7 +8,6 @@ import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
 
 import static uk.gov.companieshouse.api.util.security.Permission.Key.USER_PSC_DISCREPANCY_REPORT;
 
-
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 

--- a/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
+++ b/src/main/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfig.java
@@ -1,19 +1,10 @@
 package uk.gov.ch.pscdiscrepanciesapi.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import uk.gov.ch.pscdiscrepanciesapi.PscDiscrepancyApiApplication;
 import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
-
-import uk.gov.companieshouse.environment.EnvironmentReader;
-import uk.gov.companieshouse.environment.impl.EnvironmentReaderImpl;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
-
-import java.beans.PersistenceDelegate;
 
 import static uk.gov.companieshouse.api.util.security.Permission.Key.USER_PSC_DISCREPANCY_REPORT;
 
@@ -21,14 +12,10 @@ import static uk.gov.companieshouse.api.util.security.Permission.Key.USER_PSC_DI
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 
-    @Autowired
-    private static final Logger LOG = LoggerFactory.getLogger(PscDiscrepancyApiApplication.APP_NAMESPACE);
-
     @Bean
     public CRUDAuthenticationInterceptor crudAuthenticationInterceptor(){
         return new CRUDAuthenticationInterceptor(USER_PSC_DISCREPANCY_REPORT);
     }
-
     @Override
     public void addInterceptors(InterceptorRegistry registry){
         registry.addInterceptor(crudAuthenticationInterceptor());

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -8,7 +8,6 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
 
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,13 +23,9 @@ class InterceptorConfigTest {
     @Mock
     InterceptorRegistry registry;
 
-    @Mock
-    InterceptorRegistration crudPermissionInterceptorRegistration;
-
     @Test
     void testThatConfigInterceptorAddsTheCrudAuthenticationInterceptorAddsSucessfully(){
         when(interceptorConfig.crudAuthenticationInterceptor()).thenReturn(crudAuthenticationInterceptor);
-        when(registry.addInterceptor(crudAuthenticationInterceptor)).thenReturn(crudPermissionInterceptorRegistration);
         interceptorConfig.addInterceptors(registry);
         InOrder order = Mockito.inOrder(registry);
         order.verify(registry).addInterceptor(crudAuthenticationInterceptor);

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -24,10 +24,12 @@ class InterceptorConfigTest {
     @Mock
     InterceptorRegistry registry;
 
+    @Mock
+    InterceptorRegistration crudPermissionInterceptorRegistration;
+
     @Test
     void testThatConfigInterceptorAddsTheCrudAuthenticationInterceptorAddsSucessfully(){
         when(interceptorConfig.crudAuthenticationInterceptor()).thenReturn(crudAuthenticationInterceptor);
-        InterceptorRegistration crudPermissionInterceptorRegistration = Mockito.mock(InterceptorRegistration.class);
         doReturn(crudPermissionInterceptorRegistration).when(registry).addInterceptor(crudAuthenticationInterceptor);
         interceptorConfig.addInterceptors(registry);
         InOrder order = Mockito.inOrder(registry);

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class InterceptorConfigTest {
+class InterceptorConfigTest {
 
     @Spy
     @InjectMocks

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -1,0 +1,35 @@
+package uk.gov.ch.pscdiscrepanciesapi.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import uk.gov.companieshouse.api.interceptor.CRUDAuthenticationInterceptor;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class InterceptorConfigTest {
+
+    @Spy
+    @InjectMocks
+    InterceptorConfig interceptorConfig;
+
+    @Mock
+    CRUDAuthenticationInterceptor crudAuthenticationInterceptor;
+
+    @Test
+    void testThatConfigInterceptorAddsTheCrudAuthenticationInterceptorAddsSucessfully(){
+        when(interceptorConfig.crudAuthenticationInterceptor()).thenReturn(crudAuthenticationInterceptor);
+        InterceptorRegistry registry = Mockito.mock(InterceptorRegistry.class);
+        InterceptorRegistration crudPermissionInterceptorRegistration = Mockito.mock(InterceptorRegistration.class);
+        doReturn(crudPermissionInterceptorRegistration).when(registry).addInterceptor(crudAuthenticationInterceptor);
+        interceptorConfig.addInterceptors(registry);
+        InOrder order = Mockito.inOrder(registry);
+        order.verify(registry).addInterceptor(crudAuthenticationInterceptor);
+    }
+
+}

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -30,7 +30,7 @@ class InterceptorConfigTest {
     @Test
     void testThatConfigInterceptorAddsTheCrudAuthenticationInterceptorAddsSucessfully(){
         when(interceptorConfig.crudAuthenticationInterceptor()).thenReturn(crudAuthenticationInterceptor);
-        doReturn(crudPermissionInterceptorRegistration).when(registry).addInterceptor(crudAuthenticationInterceptor);
+        when(registry.addInterceptor(crudAuthenticationInterceptor)).thenReturn(crudPermissionInterceptorRegistration);
         interceptorConfig.addInterceptors(registry);
         InOrder order = Mockito.inOrder(registry);
         order.verify(registry).addInterceptor(crudAuthenticationInterceptor);

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -21,10 +21,12 @@ class InterceptorConfigTest {
     @Mock
     CRUDAuthenticationInterceptor crudAuthenticationInterceptor;
 
+    @Mock
+    InterceptorRegistry registry;
+
     @Test
     void testThatConfigInterceptorAddsTheCrudAuthenticationInterceptorAddsSucessfully(){
         when(interceptorConfig.crudAuthenticationInterceptor()).thenReturn(crudAuthenticationInterceptor);
-        InterceptorRegistry registry = Mockito.mock(InterceptorRegistry.class);
         InterceptorRegistration crudPermissionInterceptorRegistration = Mockito.mock(InterceptorRegistration.class);
         doReturn(crudPermissionInterceptorRegistration).when(registry).addInterceptor(crudAuthenticationInterceptor);
         interceptorConfig.addInterceptors(registry);

--- a/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
+++ b/src/test/java/uk/gov/ch/pscdiscrepanciesapi/config/InterceptorConfigTest.java
@@ -15,13 +15,13 @@ class InterceptorConfigTest {
 
     @Spy
     @InjectMocks
-    InterceptorConfig interceptorConfig;
+    private InterceptorConfig interceptorConfig;
 
     @Mock
-    CRUDAuthenticationInterceptor crudAuthenticationInterceptor;
+    private CRUDAuthenticationInterceptor crudAuthenticationInterceptor;
 
     @Mock
-    InterceptorRegistry registry;
+    private InterceptorRegistry registry;
 
     @Test
     void testThatConfigInterceptorAddsTheCrudAuthenticationInterceptorAddsSucessfully(){


### PR DESCRIPTION
- add pom entry for api-security-java version with token permission for psc_discrepancy_report
- add InterceptorConfig.java to add the CRUDAuthenticationInterceptor that uses the new token permission
- add test to go along with the new method

Jira ticket: https://companieshouse.atlassian.net/browse/FAML-635